### PR TITLE
feature: add ability to export a json schema for opslevel.yaml

### DIFF
--- a/changes/unreleased/Feature-20211201-144350.yaml
+++ b/changes/unreleased/Feature-20211201-144350.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add ability to export a json schema for opslevel.yaml
+time: 2021-12-01T14:43:50.606863-06:00

--- a/src/cmd/opslevel.go
+++ b/src/cmd/opslevel.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/alecthomas/jsonschema"
+	"github.com/spf13/cobra"
+)
+
+type OpsLevelTag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type OpsLevelTool struct {
+	Name        string `json:"name"`
+	Category    string `json:"category"` // TODO: this should be an enum
+	Url         string `json:"url"`
+	Environment string `json:"environment,omitempty"`
+}
+
+type OpsLevelRepository struct {
+	Name     string `json:"name"`
+	Path     string `json:"path,omitempty"`
+	Provider string `json:"provider"` // TODO: this should be an enum
+}
+
+type OpsLevelService struct {
+	Name         string               `json:"name"`
+	Description  string               `json:"description"`
+	Owner        string               `json:"owner"`
+	Lifecycle    string               `json:"lifecycle"`
+	Tier         string               `json:"tier"`
+	Product      string               `json:"product"`
+	Language     string               `json:"language"`
+	Framework    string               `json:"framework"`
+	Aliases      []string             `json:"aliases"` // JQ expressions that return a single string or a []string
+	Tags         []OpsLevelTag        `json:"tags"`
+	Tools        []OpsLevelTool       `json:"tools"`        // JQ expressions that return a single map[string]string or a []map[string]string
+	Repositories []OpsLevelRepository `json:"repositories"` // JQ expressions that return a single string or []string or map[string]string or a []map[string]string
+	// TODO: Dependencies
+}
+
+type OpsLevelConfig struct {
+	Version int             `json:"version"`
+	Service OpsLevelService `json:"service"`
+}
+
+var opslevelSchemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Print the jsonschema for opslevel.yml file",
+	Long:  "Print the jsonschema for opslevel.yml file",
+	Run: func(cmd *cobra.Command, args []string) {
+		schema := jsonschema.Reflect(&OpsLevelConfig{})
+		jsonBytes, jsonErr := json.MarshalIndent(schema, "", "  ")
+		cobra.CheckErr(jsonErr)
+		fmt.Println(string(jsonBytes))
+	},
+}
+
+func init() {
+	exportCmd.AddCommand(opslevelSchemaCmd)
+}

--- a/src/cmd/opslevel.go
+++ b/src/cmd/opslevel.go
@@ -9,6 +9,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type OpsLevelAlias struct{}
+
+func (OpsLevelAlias) JSONSchemaType() *jsonschema.Type {
+	return &jsonschema.Type{
+		Type:      "string",
+		MinLength: 1,
+		MaxLength: 255,
+	}
+}
+
 type OpsLevelTag struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
@@ -40,7 +50,7 @@ type OpsLevelService struct {
 	Product      string                      `json:"product,omitempty"`
 	Language     string                      `json:"language,omitempty"`
 	Framework    string                      `json:"framework,omitempty"`
-	Aliases      []string                    `json:"aliases,omitempty"`
+	Aliases      []OpsLevelAlias             `json:"aliases,omitempty"`
 	Tags         []OpsLevelTag               `json:"tags,omitempty"`
 	Tools        []OpsLevelTool              `json:"tools,omitempty"`
 	Repositories []OpsLevelRepository        `json:"repositories,omitempty"`
@@ -48,8 +58,9 @@ type OpsLevelService struct {
 }
 
 type OpsLevelConfig struct {
-	Version int             `json:"version"`
-	Service OpsLevelService `json:"service"`
+	Version    int                `json:"version"`
+	Service    OpsLevelService    `json:"service" jsonschema:"oneof_required=service"`
+	Repository OpsLevelRepository `json:"repository" jsonschema:"oneof_required=repository"`
 }
 
 var opslevelSchemaCmd = &cobra.Command{

--- a/src/cmd/opslevel.go
+++ b/src/cmd/opslevel.go
@@ -19,9 +19,20 @@ func (OpsLevelAlias) JSONSchemaType() *jsonschema.Type {
 	}
 }
 
+type OpsLevelTagKey string
+
+func (OpsLevelTagKey) JSONSchemaType() *jsonschema.Type {
+	return &jsonschema.Type{
+		Type:      "string",
+		MinLength: 1,
+		MaxLength: 200,
+		Pattern:   "^[A-Za-z][0-9A-Za-z_.\\/\\-]*$",
+	}
+}
+
 type OpsLevelTag struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   OpsLevelTagKey `json:"key"`
+	Value string         `json:"value"`
 }
 
 type OpsLevelTool struct {
@@ -32,9 +43,10 @@ type OpsLevelTool struct {
 }
 
 type OpsLevelRepository struct {
-	Name     string `json:"name"`
-	Path     string `json:"path,omitempty"`
-	Provider string `json:"provider"` // TODO: this should be an enum
+	Name        string `json:"name"`
+	Path        string `json:"path,omitempty"`
+	Provider    string `json:"provider"` // TODO: this should be an enum
+	DisplayName string `json:"displayName,omitempty"`
 }
 
 type OpsLevelServiceDependancy struct {

--- a/src/cmd/opslevel.go
+++ b/src/cmd/opslevel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alecthomas/jsonschema"
+	"github.com/opslevel/opslevel-go"
 	"github.com/spf13/cobra"
 )
 
@@ -14,10 +15,10 @@ type OpsLevelTag struct {
 }
 
 type OpsLevelTool struct {
-	Name        string `json:"name"`
-	Category    string `json:"category"` // TODO: this should be an enum
-	Url         string `json:"url"`
-	Environment string `json:"environment,omitempty"`
+	Name        string                `json:"name"`
+	Category    opslevel.ToolCategory `json:"category"`
+	Url         string                `json:"url"`
+	Environment string                `json:"environment,omitempty"`
 }
 
 type OpsLevelRepository struct {
@@ -26,20 +27,24 @@ type OpsLevelRepository struct {
 	Provider string `json:"provider"` // TODO: this should be an enum
 }
 
+type OpsLevelServiceDependancy struct {
+	Alias string `json:"alias"`
+}
+
 type OpsLevelService struct {
-	Name         string               `json:"name"`
-	Description  string               `json:"description"`
-	Owner        string               `json:"owner"`
-	Lifecycle    string               `json:"lifecycle"`
-	Tier         string               `json:"tier"`
-	Product      string               `json:"product"`
-	Language     string               `json:"language"`
-	Framework    string               `json:"framework"`
-	Aliases      []string             `json:"aliases"` // JQ expressions that return a single string or a []string
-	Tags         []OpsLevelTag        `json:"tags"`
-	Tools        []OpsLevelTool       `json:"tools"`        // JQ expressions that return a single map[string]string or a []map[string]string
-	Repositories []OpsLevelRepository `json:"repositories"` // JQ expressions that return a single string or []string or map[string]string or a []map[string]string
-	// TODO: Dependencies
+	Name         string                      `json:"name"`
+	Description  string                      `json:"description,omitempty"`
+	Owner        string                      `json:"owner,omitempty"`
+	Lifecycle    string                      `json:"lifecycle,omitempty"`
+	Tier         string                      `json:"tier,omitempty"`
+	Product      string                      `json:"product,omitempty"`
+	Language     string                      `json:"language,omitempty"`
+	Framework    string                      `json:"framework,omitempty"`
+	Aliases      []string                    `json:"aliases,omitempty"`
+	Tags         []OpsLevelTag               `json:"tags,omitempty"`
+	Tools        []OpsLevelTool              `json:"tools,omitempty"`
+	Repositories []OpsLevelRepository        `json:"repositories,omitempty"`
+	Dependencies []OpsLevelServiceDependancy `json:"dependencies,omitempty"`
 }
 
 type OpsLevelConfig struct {

--- a/src/go.mod
+++ b/src/go.mod
@@ -3,6 +3,7 @@ module github.com/opslevel/cli
 go 1.17
 
 require (
+	github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc
 	github.com/creasty/defaults v1.5.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gosimple/slug v1.12.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -46,6 +46,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc h1:mT8qSzuyEAkxbv4GBln7yeuQZpBnfikr3PTuiPs6Z3k=
+github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -197,6 +199,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
@@ -297,6 +301,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Add the command `opslevel export schema` which emits a json schema of the structure which mirrors opslevel.yml