### PR TITLE
only build the client when needed

### DIFF
--- a/changes/unreleased/Refactor-20220207-213752.yaml
+++ b/changes/unreleased/Refactor-20220207-213752.yaml
@@ -1,0 +1,4 @@
+kind: Refactor
+body: Fix code so client objects are not built unless needed allow commands like `opslevel
+  version` to execute without an OPSLEVEL_API_TOKEN present
+time: 2022-02-07T21:37:52.107962-06:00

--- a/src/cmd/account.go
+++ b/src/cmd/account.go
@@ -16,7 +16,7 @@ var lifecycleCmd = &cobra.Command{
 	Short:   "Lists lifecycles",
 	Long:    `Lists lifecycles`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListLifecycles()
+		list, err := getClientGQL().ListLifecycles()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
@@ -36,7 +36,7 @@ var tierCmd = &cobra.Command{
 	Short:   "Lists tiers",
 	Long:    `Lists tiers`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListTiers()
+		list, err := getClientGQL().ListTiers()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -18,7 +18,7 @@ var getCheckCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
-		check, err := graphqlClient.GetCheck(args[0])
+		check, err := getClientGQL().GetCheck(args[0])
 		cobra.CheckErr(err)
 		if isYamlOutput() {
 			common.YamlPrint(marshalCheck(*check))
@@ -34,7 +34,7 @@ var listCheckCmd = &cobra.Command{
 	Short:   "Lists the rubric checks",
 	Long:    `Lists the rubric checks`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListChecks()
+		list, err := getClientGQL().ListChecks()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
@@ -74,7 +74,7 @@ var deleteCheckCmd = &cobra.Command{
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		err := graphqlClient.DeleteCheck(key)
+		err := getClientGQL().DeleteCheck(key)
 		cobra.CheckErr(err)
 		fmt.Printf("deleted '%s' check\n", key)
 	},
@@ -195,42 +195,43 @@ func (self *CheckCreateType) AsCustomEventCreateInput() *opslevel.CheckCustomEve
 func createCheck(input CheckCreateType) (*opslevel.Check, error) {
 	var output *opslevel.Check
 	var err error
-	opslevel.Cache.CacheCategories(graphqlClient)
-	opslevel.Cache.CacheLevels(graphqlClient)
-	opslevel.Cache.CacheTeams(graphqlClient)
-	opslevel.Cache.CacheFilters(graphqlClient)
+	clientGQL := getClientGQL()
+	opslevel.Cache.CacheCategories(clientGQL)
+	opslevel.Cache.CacheLevels(clientGQL)
+	opslevel.Cache.CacheTeams(clientGQL)
+	opslevel.Cache.CacheFilters(clientGQL)
 	input.resolveAliases()
 	switch input.Kind {
 	case opslevel.CheckTypeHasOwner:
-		output, err = graphqlClient.CreateCheckServiceOwnership(*input.AsServiceOwnershipCreateInput())
+		output, err = clientGQL.CreateCheckServiceOwnership(*input.AsServiceOwnershipCreateInput())
 
 	case opslevel.CheckTypeServiceProperty:
-		output, err = graphqlClient.CreateCheckServiceProperty(*input.AsServicePropertyCreateInput())
+		output, err = clientGQL.CreateCheckServiceProperty(*input.AsServicePropertyCreateInput())
 
 	case opslevel.CheckTypeHasServiceConfig:
-		output, err = graphqlClient.CreateCheckServiceConfiguration(*input.AsServiceConfigurationCreateInput())
+		output, err = clientGQL.CreateCheckServiceConfiguration(*input.AsServiceConfigurationCreateInput())
 
 	case opslevel.CheckTypeHasRepository:
-		output, err = graphqlClient.CreateCheckRepositoryIntegrated(*input.AsRepositoryIntegratedCreateInput())
+		output, err = clientGQL.CreateCheckRepositoryIntegrated(*input.AsRepositoryIntegratedCreateInput())
 
 	case opslevel.CheckTypeToolUsage:
-		output, err = graphqlClient.CreateCheckToolUsage(*input.AsToolUsageCreateInput())
+		output, err = clientGQL.CreateCheckToolUsage(*input.AsToolUsageCreateInput())
 
 	case opslevel.CheckTypeTagDefined:
-		output, err = graphqlClient.CreateCheckTagDefined(*input.AsTagDefinedCreateInput())
+		output, err = clientGQL.CreateCheckTagDefined(*input.AsTagDefinedCreateInput())
 
 	case opslevel.CheckTypeRepoFile:
-		output, err = graphqlClient.CreateCheckRepositoryFile(*input.AsRepositoryFileCreateInput())
+		output, err = clientGQL.CreateCheckRepositoryFile(*input.AsRepositoryFileCreateInput())
 
 	case opslevel.CheckTypeRepoSearch:
-		output, err = graphqlClient.CreateCheckRepositorySearch(*input.AsRepositorySearchCreateInput())
+		output, err = clientGQL.CreateCheckRepositorySearch(*input.AsRepositorySearchCreateInput())
 
 	case opslevel.CheckTypeManual:
-		output, err = graphqlClient.CreateCheckManual(*input.AsManualCreateInput())
+		output, err = clientGQL.CreateCheckManual(*input.AsManualCreateInput())
 
 	case opslevel.CheckTypeGeneric:
-		opslevel.Cache.CacheIntegrations(graphqlClient)
-		output, err = graphqlClient.CreateCheckCustomEvent(*input.AsCustomEventCreateInput())
+		opslevel.Cache.CacheIntegrations(clientGQL)
+		output, err = clientGQL.CreateCheckCustomEvent(*input.AsCustomEventCreateInput())
 	}
 	cobra.CheckErr(err)
 	if output == nil {

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -59,7 +59,7 @@ var deployCreateCmd = &cobra.Command{
 			var resp struct {
 				Result string `json:"result"`
 			}
-			err = restClient.Do("POST", integrationUrl, evt, &resp)
+			err = getClientRest().Do("POST", integrationUrl, evt, &resp)
 			cobra.CheckErr(err)
 			log.Info().Msgf("Successfully registered deploy event for '%s'", evt.Service)
 		}

--- a/src/cmd/filter.go
+++ b/src/cmd/filter.go
@@ -16,7 +16,7 @@ var createFilterCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"NAME"},
 	Run: func(cmd *cobra.Command, args []string) {
-		filter, err := graphqlClient.CreateFilter(opslevel.FilterCreateInput{
+		filter, err := getClientGQL().CreateFilter(opslevel.FilterCreateInput{
 			Name: args[0],
 		})
 		cobra.CheckErr(err)
@@ -31,7 +31,7 @@ var getFilterCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
-		filter, err := graphqlClient.GetFilter(args[0])
+		filter, err := getClientGQL().GetFilter(args[0])
 		cobra.CheckErr(err)
 		common.PrettyPrint(filter)
 	},
@@ -43,7 +43,7 @@ var listFilterCmd = &cobra.Command{
 	Short:   "Lists filters",
 	Long:    `Lists filters`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListFilters()
+		list, err := getClientGQL().ListFilters()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
@@ -65,7 +65,7 @@ var deleteFilterCmd = &cobra.Command{
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		err := graphqlClient.DeleteFilter(key)
+		err := getClientGQL().DeleteFilter(key)
 		cobra.CheckErr(err)
 		fmt.Printf("deleted '%s' filter\n", key)
 	},

--- a/src/cmd/integration.go
+++ b/src/cmd/integration.go
@@ -15,7 +15,7 @@ var getIntegrationCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
-		integration, err := graphqlClient.GetIntegration(args[0])
+		integration, err := getClientGQL().GetIntegration(args[0])
 		cobra.CheckErr(err)
 		common.PrettyPrint(integration)
 	},
@@ -27,7 +27,7 @@ var listIntegrationCmd = &cobra.Command{
 	Short:   "Lists integrations",
 	Long:    `Lists integrations`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListIntegrations()
+		list, err := getClientGQL().ListIntegrations()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))

--- a/src/cmd/repository.go
+++ b/src/cmd/repository.go
@@ -20,10 +20,10 @@ var getRepositoryCmd = &cobra.Command{
 		var repository *opslevel.Repository
 		var err error
 		if common.IsID(key) {
-			repository, err = graphqlClient.GetRepository(key)
+			repository, err = getClientGQL().GetRepository(key)
 			cobra.CheckErr(err)
 		} else {
-			repository, err = graphqlClient.GetRepositoryWithAlias(key)
+			repository, err = getClientGQL().GetRepositoryWithAlias(key)
 			cobra.CheckErr(err)
 		}
 		cobra.CheckErr(err)
@@ -37,7 +37,7 @@ var listRepositoryCmd = &cobra.Command{
 	Short:   "Lists repositories",
 	Long:    `Lists repositories`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListRepositories()
+		list, err := getClientGQL().ListRepositories()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-var restClient *common.Client
-var graphqlClient *opslevel.Client
+var _clientRest *common.Client
+var _clientGQL *opslevel.Client
 
 var rootCmd = &cobra.Command{
 	Use:   "opslevel",
@@ -44,7 +44,6 @@ func initConfig() {
 	viper.SetEnvPrefix("OPSLEVEL")
 	viper.AutomaticEnv()
 	setupLogging()
-	createClients()
 }
 
 func setupLogging() {
@@ -70,7 +69,16 @@ func setupLogging() {
 	}
 }
 
-func createClients() {
-	restClient = common.NewRestClient()
-	graphqlClient = common.NewGraphClient(version)
+func getClientRest() *common.Client {
+	if _clientRest == nil {
+		_clientRest = common.NewRestClient()
+	}
+	return _clientRest
+}
+
+func getClientGQL() *opslevel.Client {
+	if _clientGQL == nil {
+		_clientGQL = common.NewGraphClient(version)
+	}
+	return _clientGQL
 }

--- a/src/cmd/rubric.go
+++ b/src/cmd/rubric.go
@@ -16,7 +16,7 @@ var createCategoryCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"NAME"},
 	Run: func(cmd *cobra.Command, args []string) {
-		category, err := graphqlClient.CreateCategory(opslevel.CategoryCreateInput{
+		category, err := getClientGQL().CreateCategory(opslevel.CategoryCreateInput{
 			Name: args[0],
 		})
 		cobra.CheckErr(err)
@@ -31,7 +31,7 @@ var getCategoryCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
-		category, err := graphqlClient.GetCategory(args[0])
+		category, err := getClientGQL().GetCategory(args[0])
 		cobra.CheckErr(err)
 		common.PrettyPrint(category)
 	},
@@ -43,7 +43,7 @@ var listCategoryCmd = &cobra.Command{
 	Short:   "Lists rubric categories",
 	Long:    `Lists rubric categories`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListCategories()
+		list, err := getClientGQL().ListCategories()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
@@ -65,7 +65,7 @@ var deleteCategoryCmd = &cobra.Command{
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		err := graphqlClient.DeleteCategory(key)
+		err := getClientGQL().DeleteCategory(key)
 		cobra.CheckErr(err)
 		fmt.Printf("deleted '%s' category\n", key)
 	},
@@ -78,7 +78,7 @@ var createLevelCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"NAME"},
 	Run: func(cmd *cobra.Command, args []string) {
-		category, err := graphqlClient.CreateLevel(opslevel.LevelCreateInput{
+		category, err := getClientGQL().CreateLevel(opslevel.LevelCreateInput{
 			Name: args[0],
 		})
 		cobra.CheckErr(err)
@@ -93,7 +93,7 @@ var getLevelCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
-		level, err := graphqlClient.GetLevel(args[0])
+		level, err := getClientGQL().GetLevel(args[0])
 		cobra.CheckErr(err)
 		common.PrettyPrint(level)
 	},
@@ -105,7 +105,7 @@ var listLevelCmd = &cobra.Command{
 	Short:   "Lists rubric levels",
 	Long:    `Lists rubric levels`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListLevels()
+		list, err := getClientGQL().ListLevels()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
@@ -127,7 +127,7 @@ var deleteLevelCmd = &cobra.Command{
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		err := graphqlClient.DeleteLevel(key)
+		err := getClientGQL().DeleteLevel(key)
 		cobra.CheckErr(err)
 		fmt.Printf("deleted '%s' level\n", key)
 	},

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -19,7 +19,7 @@ var createServiceCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		input, err := readServiceCreateInput()
 		cobra.CheckErr(err)
-		service, err := graphqlClient.CreateService(*input)
+		service, err := getClientGQL().CreateService(*input)
 		cobra.CheckErr(err)
 		fmt.Println(service.Id)
 	},
@@ -36,10 +36,10 @@ var getServiceCmd = &cobra.Command{
 		var service *opslevel.Service
 		var err error
 		if common.IsID(key) {
-			service, err = graphqlClient.GetService(key)
+			service, err = getClientGQL().GetService(key)
 			cobra.CheckErr(err)
 		} else {
-			service, err = graphqlClient.GetServiceWithAlias(key)
+			service, err = getClientGQL().GetServiceWithAlias(key)
 			cobra.CheckErr(err)
 		}
 		cobra.CheckErr(err)
@@ -53,7 +53,7 @@ var listServiceCmd = &cobra.Command{
 	Short:   "Lists services",
 	Long:    `Lists services`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListServices()
+		list, err := getClientGQL().ListServices()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
@@ -74,7 +74,7 @@ var updateServiceCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		input, err := readServiceUpdateInput()
 		cobra.CheckErr(err)
-		service, err := graphqlClient.UpdateService(*input)
+		service, err := getClientGQL().UpdateService(*input)
 		cobra.CheckErr(err)
 		common.JsonPrint(json.MarshalIndent(service, "", "    "))
 	},
@@ -90,12 +90,12 @@ var deleteServiceCmd = &cobra.Command{
 		key := args[0]
 		var err error
 		if common.IsID(key) {
-			err = graphqlClient.DeleteService(opslevel.ServiceDeleteInput{
+			err = getClientGQL().DeleteService(opslevel.ServiceDeleteInput{
 				Id: key,
 			})
 			cobra.CheckErr(err)
 		} else {
-			err = graphqlClient.DeleteServiceWithAlias(key)
+			err = getClientGQL().DeleteServiceWithAlias(key)
 			cobra.CheckErr(err)
 		}
 		cobra.CheckErr(err)

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -16,7 +16,7 @@ var createTeamCmd = &cobra.Command{
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"NAME"},
 	Run: func(cmd *cobra.Command, args []string) {
-		team, err := graphqlClient.CreateTeam(opslevel.TeamCreateInput{
+		team, err := getClientGQL().CreateTeam(opslevel.TeamCreateInput{
 			Name: args[0],
 		})
 		cobra.CheckErr(err)
@@ -37,14 +37,14 @@ var createMemberCmd = &cobra.Command{
 		var team *opslevel.Team
 		var err error
 		if common.IsID(key) {
-			team, err = graphqlClient.GetTeam(key)
+			team, err = getClientGQL().GetTeam(key)
 		} else {
-			team, err = graphqlClient.GetTeamWithAlias(key)
+			team, err = getClientGQL().GetTeamWithAlias(key)
 		}
 		cobra.CheckErr(err)
 		common.WasFound(team.Id == nil, key)
 
-		_, addErr := graphqlClient.AddMember(&team.TeamId, email)
+		_, addErr := getClientGQL().AddMember(&team.TeamId, email)
 		cobra.CheckErr(addErr)
 		fmt.Printf("add member '%s' on team '%s'\n", email, team.Alias)
 	},
@@ -65,9 +65,9 @@ var createContactCmd = &cobra.Command{
 		var team *opslevel.Team
 		var err error
 		if common.IsID(key) {
-			team, err = graphqlClient.GetTeam(key)
+			team, err = getClientGQL().GetTeam(key)
 		} else {
-			team, err = graphqlClient.GetTeamWithAlias(key)
+			team, err = getClientGQL().GetTeamWithAlias(key)
 		}
 		cobra.CheckErr(err)
 		common.WasFound(team.Id == nil, key)
@@ -78,7 +78,7 @@ var createContactCmd = &cobra.Command{
 		case string(opslevel.ContactTypeWeb):
 			contactInput = opslevel.CreateContactWeb(address, displayName)
 		}
-		contact, err := graphqlClient.AddContact(&team.TeamId, contactInput)
+		contact, err := getClientGQL().AddContact(&team.TeamId, contactInput)
 		cobra.CheckErr(err)
 		if contact.Id == nil {
 			cobra.CheckErr(fmt.Errorf("unable to create contact '%+v'", contactInput))
@@ -98,9 +98,9 @@ var getTeamCmd = &cobra.Command{
 		var team *opslevel.Team
 		var err error
 		if common.IsID(key) {
-			team, err = graphqlClient.GetTeam(key)
+			team, err = getClientGQL().GetTeam(key)
 		} else {
-			team, err = graphqlClient.GetTeamWithAlias(key)
+			team, err = getClientGQL().GetTeamWithAlias(key)
 		}
 		cobra.CheckErr(err)
 		common.PrettyPrint(team)
@@ -114,7 +114,7 @@ var listTeamCmd = &cobra.Command{
 	Short:   "Lists the teams",
 	Long:    `Lists the teams`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := graphqlClient.ListTeams()
+		list, err := getClientGQL().ListTeams()
 		cobra.CheckErr(err)
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
@@ -137,10 +137,10 @@ var deleteTeamCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
 		if common.IsID(key) {
-			err := graphqlClient.DeleteTeam(key)
+			err := getClientGQL().DeleteTeam(key)
 			cobra.CheckErr(err)
 		} else {
-			err := graphqlClient.DeleteTeamWithAlias(key)
+			err := getClientGQL().DeleteTeamWithAlias(key)
 			cobra.CheckErr(err)
 		}
 		fmt.Printf("team '%s' deleted\n", key)
@@ -160,14 +160,14 @@ var deleteMemberCmd = &cobra.Command{
 		var team *opslevel.Team
 		var err error
 		if common.IsID(key) {
-			team, err = graphqlClient.GetTeam(key)
+			team, err = getClientGQL().GetTeam(key)
 		} else {
-			team, err = graphqlClient.GetTeamWithAlias(key)
+			team, err = getClientGQL().GetTeamWithAlias(key)
 		}
 		cobra.CheckErr(err)
 		common.WasFound(team.Id == nil, key)
 
-		_, removeErr := graphqlClient.RemoveMember(&team.TeamId, email)
+		_, removeErr := getClientGQL().RemoveMember(&team.TeamId, email)
 		cobra.CheckErr(removeErr)
 		fmt.Printf("member '%s' on team '%s' removed\n", email, key)
 	},
@@ -181,7 +181,7 @@ var deleteContactCmd = &cobra.Command{
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		err := graphqlClient.RemoveContact(key)
+		err := getClientGQL().RemoveContact(key)
 		cobra.CheckErr(err)
 		fmt.Printf("contact '%s' removed\n", key)
 	},


### PR DESCRIPTION
This converts the logic to only build the clients when a command actually uses them.  So commands like `opslevel version` don't error out with 
```
Error: Client Validation Error: Please provide a valid OpsLevel API token via 'export OPSLEVEL_API_TOKEN=XXX' or '--api-token=XXX'
```