### PR TITLE
Add User commands

### DIFF
--- a/.changes/unreleased/Feature-20220604-085836.yaml
+++ b/.changes/unreleased/Feature-20220604-085836.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Added create, list and delete user commands
+time: 2022-06-04T08:58:36.64737-05:00

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -78,7 +78,7 @@ var createContactCmd = &cobra.Command{
 		case string(opslevel.ContactTypeWeb):
 			contactInput = opslevel.CreateContactWeb(address, displayName)
 		}
-		contact, err := getClientGQL().AddContact(&team.TeamId, contactInput)
+		contact, err := getClientGQL().AddContact(team.TeamId.Alias, contactInput)
 		cobra.CheckErr(err)
 		if contact.Id == nil {
 			cobra.CheckErr(fmt.Errorf("unable to create contact '%+v'", contactInput))

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/opslevel/cli/common"
+	"github.com/opslevel/opslevel-go"
+	"github.com/spf13/cobra"
+	"sort"
+)
+
+var createUserCmd = &cobra.Command{
+	Use:        "user EMAIL NAME",
+	Short:      "Create a User",
+	Long:       `Create a User`,
+	Args:       cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		email := args[0]
+		name := args[1]
+
+		resource, err := getClientGQL().InviteUser(email, opslevel.UserInput{
+			Name: name,
+		})
+		cobra.CheckErr(err)
+		fmt.Println(resource.Id)
+	},
+}
+
+var listUserCmd = &cobra.Command{
+	Use:     "user",
+	Aliases: []string{"users"},
+	Short:   "Lists the users",
+	Long:    `Lists the users`,
+	Run: func(cmd *cobra.Command, args []string) {
+		list, err := getClientGQL().ListUsers()
+		sort.Slice(list, func(i, j int) bool {
+			return list[i].Email < list[j].Email
+		})
+		cobra.CheckErr(err)
+		if isJsonOutput() {
+			common.JsonPrint(json.MarshalIndent(list, "", "    "))
+		} else {
+			w := common.NewTabWriter("NAME", "EMAIL", "ID")
+			for _, item := range list {
+				fmt.Fprintf(w, "%s\t%s\t%s\t\n", item.Name, item.Email, item.Id)
+			}
+			w.Flush()
+		}
+	},
+}
+
+var deleteUserCmd = &cobra.Command{
+	Use:        "user ID",
+	Short:      "Delete a User",
+	Long:       `Delete a User`,
+	Args:       cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		key := args[0]
+
+		err := getClientGQL().DeleteUser(args[0])
+		cobra.CheckErr(err)
+
+		fmt.Printf("user '%s' deleted\n", key)
+	},
+}
+
+func init() {
+	createCmd.AddCommand(createUserCmd)
+	listCmd.AddCommand(listUserCmd)
+	deleteCmd.AddCommand(deleteUserCmd)
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -56,4 +56,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-//replace github.com/opslevel/opslevel-go => ./submodules/opslevel-go
+replace github.com/opslevel/opslevel-go => ./submodules/opslevel-go


### PR DESCRIPTION
This adds the create, list and delete user commands because the opslevel-go portion is now implemented.

I'm leaving off get user because it requires a user ID and thats not a great UX.  The API will eventually support looking up an user by email so once we do that we will implement that in the CLI.

