### PR TITLE
Add CSV import commands

### DIFF
--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/rs/zerolog/log"
 
 	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
@@ -283,6 +284,40 @@ var deleteGroupCmd = &cobra.Command{
 	},
 }
 
+var importGroupsCmd = &cobra.Command{
+	Use:        "group CSV_FILEPATH",
+	Aliases:    []string{"groups"},
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"CSV_FILEPATH"},
+	Short:      "Imports groups from a CSV",
+	Long: `Imports a list of groups from a CSV file with the column headers
+
+    Name,Description,Parent
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		filepath := args[0]
+		reader, err := common.ReadCSVFile(filepath)
+		cobra.CheckErr(err)
+		for reader.Rows() {
+			name := reader.Text("Name")
+			input := opslevel.GroupInput{
+				Name:        name,
+				Description: reader.Text("Description"),
+			}
+			parent := reader.Text("Parent")
+			if parent != "" {
+				input.Parent = opslevel.NewIdentifier(parent)
+			}
+			group, err := getClientGQL().CreateGroup(input)
+			if err != nil {
+				log.Error().Err(err).Msgf("error creating group '%s'", name)
+				continue
+			}
+			log.Info().Msgf("created group '%s' with id '%s'\n", group.Name, group.Id)
+		}
+	},
+}
+
 func init() {
 	createCmd.AddCommand(createGroupCmd)
 	getCmd.AddCommand(getGroupCommand)
@@ -294,6 +329,7 @@ func init() {
 	listCmd.AddCommand(listGroupCmd)
 	updateCmd.AddCommand(updateGroupCmd)
 	deleteCmd.AddCommand(deleteGroupCmd)
+	importCmd.AddCommand(importGroupsCmd)
 }
 
 func readGroupInput() (*opslevel.GroupInput, error) {

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -288,9 +288,17 @@ var importGroupsCmd = &cobra.Command{
 	Use:     "group",
 	Aliases: []string{"groups"},
 	Short:   "Imports groups from a CSV",
-	Long: `Imports a list of groups from a CSV file with the column headers
+	Long: `Imports a list of groups from a CSV file with the column headers:
+Name,Description,Parent
 
-    Name,Description,Parent
+Example:
+
+cat << EOF | opslevel import group -f -
+Name,Description,Parent
+Engineering,All of Engineering,
+Product,All of Product,engineering
+Sales,Sales BU,product
+EOF
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		reader, err := readImportFilepathAsCSV()

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -285,18 +285,15 @@ var deleteGroupCmd = &cobra.Command{
 }
 
 var importGroupsCmd = &cobra.Command{
-	Use:        "group CSV_FILEPATH",
-	Aliases:    []string{"groups"},
-	Args:       cobra.ExactArgs(1),
-	ArgAliases: []string{"CSV_FILEPATH"},
-	Short:      "Imports groups from a CSV",
+	Use:     "group CSV_FILEPATH",
+	Aliases: []string{"groups"},
+	Short:   "Imports groups from a CSV",
 	Long: `Imports a list of groups from a CSV file with the column headers
 
     Name,Description,Parent
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		filepath := args[0]
-		reader, err := common.ReadCSVFile(filepath)
+		reader, err := readImportFilepathAsCSV()
 		cobra.CheckErr(err)
 		for reader.Rows() {
 			name := reader.Text("Name")

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -285,7 +285,7 @@ var deleteGroupCmd = &cobra.Command{
 }
 
 var importGroupsCmd = &cobra.Command{
-	Use:     "group CSV_FILEPATH",
+	Use:     "group",
 	Aliases: []string{"groups"},
 	Short:   "Imports groups from a CSV",
 	Long: `Imports a list of groups from a CSV file with the column headers
@@ -310,7 +310,7 @@ var importGroupsCmd = &cobra.Command{
 				log.Error().Err(err).Msgf("error creating group '%s'", name)
 				continue
 			}
-			log.Info().Msgf("created group '%s' with id '%s'\n", group.Name, group.Id)
+			log.Info().Msgf("created group '%s' with id '%s'", group.Name, group.Id)
 		}
 	},
 }

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"errors"
+	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
 )
+
+var importFilepath string
 
 var importCmd = &cobra.Command{
 	Use:   "import",
@@ -12,4 +16,16 @@ var importCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(importCmd)
+
+	importCmd.PersistentFlags().StringVarP(&importFilepath, "filepath", "f", "-", "File to read data from. Defaults to reading from stdin.")
+}
+
+func readImportFilepathAsCSV() (*common.CSVReader, error) {
+	if importFilepath == "" {
+		return nil, errors.New("empty filepath specified")
+	}
+	if importFilepath == "-" {
+		return common.ReadCSVFile("/dev/stdin")
+	}
+	return common.ReadCSVFile(importFilepath)
 }

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -238,18 +238,15 @@ var deleteServiceTagCmd = &cobra.Command{
 }
 
 var importServicesCmd = &cobra.Command{
-	Use:        "service CSV_FILEPATH",
-	Aliases:    []string{"services"},
-	Args:       cobra.ExactArgs(1),
-	ArgAliases: []string{"CSV_FILEPATH"},
-	Short:      "Imports services from a CSV",
+	Use:     "service",
+	Aliases: []string{"services"},
+	Short:   "Imports services from a CSV",
 	Long: `Imports a list of services from a CSV file with the column headers
 
     Name,Description,Product,Language,Framework,Tier,Lifecycle,Owner
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		filepath := args[0]
-		reader, err := common.ReadCSVFile(filepath)
+		reader, err := readImportFilepathAsCSV()
 		client := getClientGQL()
 		opslevel.Cache.CacheLifecycles(client)
 		opslevel.Cache.CacheTiers(client)

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -241,9 +241,17 @@ var importServicesCmd = &cobra.Command{
 	Use:     "service",
 	Aliases: []string{"services"},
 	Short:   "Imports services from a CSV",
-	Long: `Imports a list of services from a CSV file with the column headers
+	Long: `Imports a list of services from a CSV file with the column headers:
+Name,Description,Product,Language,Framework,Tier,Lifecycle,Owner
 
-    Name,Description,Product,Language,Framework,Tier,Lifecycle,Owner
+Example:
+
+cat << EOF | opslevel import services -f -
+Name,Description,Product,Language,Framework,Tier,Lifecycle,Owner
+Service A,,,Go,Cobra,tier_1,pre_alpha,
+Service B,,,Python,Django,tier_3,beta,sales
+Service C,Test,Home,,,,,platform
+EOF
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		reader, err := readImportFilepathAsCSV()

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -284,7 +284,7 @@ var importServicesCmd = &cobra.Command{
 				log.Error().Err(err).Msgf("error creating service '%s'", name)
 				continue
 			}
-			log.Info().Msgf("created service '%s' with id '%s'\n", service.Name, service.Id)
+			log.Info().Msgf("created service '%s' with id '%s'", service.Name, service.Id)
 		}
 	},
 }

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
 
@@ -236,6 +237,61 @@ var deleteServiceTagCmd = &cobra.Command{
 	},
 }
 
+var importServicesCmd = &cobra.Command{
+	Use:        "service CSV_FILEPATH",
+	Aliases:    []string{"services"},
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"CSV_FILEPATH"},
+	Short:      "Imports services from a CSV",
+	Long: `Imports a list of services from a CSV file with the column headers
+
+    Name,Description,Product,Language,Framework,Tier,Lifecycle,Owner
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		filepath := args[0]
+		reader, err := common.ReadCSVFile(filepath)
+		client := getClientGQL()
+		opslevel.Cache.CacheLifecycles(client)
+		opslevel.Cache.CacheTiers(client)
+		opslevel.Cache.CacheTeams(client)
+		cobra.CheckErr(err)
+		for reader.Rows() {
+			name := reader.Text("Name")
+			input := opslevel.ServiceCreateInput{
+				Name:        name,
+				Description: reader.Text("Description"),
+				Product:     reader.Text("Product"),
+				Language:    reader.Text("Language"),
+				Framework:   reader.Text("Framework"),
+			}
+			tier := reader.Text("Tier")
+			if tier != "" {
+				if item, ok := opslevel.Cache.Tiers[tier]; ok {
+					input.Tier = item.Alias
+				}
+			}
+			lifecycle := reader.Text("Lifecycle")
+			if tier != "" {
+				if item, ok := opslevel.Cache.Lifecycles[lifecycle]; ok {
+					input.Lifecycle = item.Alias
+				}
+			}
+			owner := reader.Text("Owner")
+			if tier != "" {
+				if item, ok := opslevel.Cache.Teams[owner]; ok {
+					input.Owner = item.Alias
+				}
+			}
+			service, err := getClientGQL().CreateService(input)
+			if err != nil {
+				log.Error().Err(err).Msgf("error creating service '%s'", name)
+				continue
+			}
+			log.Info().Msgf("created service '%s' with id '%s'\n", service.Name, service.Id)
+		}
+	},
+}
+
 func init() {
 	createCmd.AddCommand(createServiceCmd)
 	getCmd.AddCommand(getServiceCmd)
@@ -246,6 +302,8 @@ func init() {
 	createServiceCmd.AddCommand(createServiceTagCmd)
 	getServiceCmd.AddCommand(getServiceTagCmd)
 	deleteServiceCmd.AddCommand(deleteServiceTagCmd)
+
+	importCmd.AddCommand(importServicesCmd)
 
 	createServiceTagCmd.Flags().Bool("assign", false, "Use the `tagAssign` mutation instead of `tagCreate`")
 }

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -217,7 +217,7 @@ var importTeamsCmd = &cobra.Command{
 				log.Error().Err(err).Msgf("error creating team '%s'", name)
 				continue
 			}
-			log.Info().Msgf("created team '%s' with id '%s'\n", team.Name, team.Id)
+			log.Info().Msgf("created team '%s' with id '%s'", team.Name, team.Id)
 		}
 	},
 }

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -194,9 +194,16 @@ var importTeamsCmd = &cobra.Command{
 	Use:     "team",
 	Aliases: []string{"teams"},
 	Short:   "Imports teams from a CSV",
-	Long: `Imports a list of teams from a CSV file with the column headers
+	Long: `Imports a list of teams from a CSV file with the column headers:
+Name,Manager,Responsibilities,Group
 
-    Name,Manager,Responsibilities,Group
+Example:
+
+cat << EOF | opslevel import teams -f -
+Name,Manager,Responsibilities,Group
+Platform,kyle@opslevel.com,Makes Tools,engineering
+Sales,john@opslevel.com,Sells Tools,product
+EOF
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		reader, err := readImportFilepathAsCSV()

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -191,18 +191,15 @@ var deleteContactCmd = &cobra.Command{
 }
 
 var importTeamsCmd = &cobra.Command{
-	Use:        "team CSV_FILEPATH",
-	Aliases:    []string{"teams"},
-	Args:       cobra.ExactArgs(1),
-	ArgAliases: []string{"CSV_FILEPATH"},
-	Short:      "Imports teams from a CSV",
+	Use:     "team",
+	Aliases: []string{"teams"},
+	Short:   "Imports teams from a CSV",
 	Long: `Imports a list of teams from a CSV file with the column headers
 
     Name,Manager,Responsibilities,Group
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		filepath := args[0]
-		reader, err := common.ReadCSVFile(filepath)
+		reader, err := readImportFilepathAsCSV()
 		cobra.CheckErr(err)
 		for reader.Rows() {
 			name := reader.Text("Name")

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -106,7 +106,7 @@ var importUsersCmd = &cobra.Command{
 				log.Error().Err(err).Msgf("error inviting user '%s' with email '%s'", name, email)
 				continue
 			}
-			log.Info().Msgf("Invited user '%s' with email '%s'\n", user.Name, user.Email)
+			log.Info().Msgf("invited user '%s' with email '%s'", user.Name, user.Email)
 			team := reader.Text("Team")
 			if team != "" {
 				t, err := GetTeam(team)

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -78,9 +78,17 @@ var importUsersCmd = &cobra.Command{
 	Use:     "user",
 	Aliases: []string{"users"},
 	Short:   "Imports users from a CSV",
-	Long: `Imports a list of users from a CSV file with the column headers
+	Long: `Imports a list of users from a CSV file with the column headers:
+Name,Email,Role,Team
 
-    Name,Email,Role,Team
+Example:
+
+cat << EOF | opslevel import user -f -
+Name,Email,Role,Team
+Kyle Rockman,kyle@opslevel.com,Admin,platform
+Edger Ochoa,edgar@opslevel.com,Admin,platform
+Adam Del Gobbo,adam@opslevel.com,User,sales
+EOF
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		reader, err := readImportFilepathAsCSV()

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -75,18 +75,15 @@ func Contains[T comparable](s []T, e T) bool {
 }
 
 var importUsersCmd = &cobra.Command{
-	Use:        "user CSV_FILEPATH",
-	Aliases:    []string{"users"},
-	Args:       cobra.ExactArgs(1),
-	ArgAliases: []string{"CSV_FILEPATH"},
-	Short:      "Imports users from a CSV",
+	Use:     "user",
+	Aliases: []string{"users"},
+	Short:   "Imports users from a CSV",
 	Long: `Imports a list of users from a CSV file with the column headers
 
     Name,Email,Role,Team
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		filepath := args[0]
-		reader, err := common.ReadCSVFile(filepath)
+		reader, err := readImportFilepathAsCSV()
 		cobra.CheckErr(err)
 		for reader.Rows() {
 			name := reader.Text("Name")

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -86,7 +86,7 @@ Example:
 cat << EOF | opslevel import user -f -
 Name,Email,Role,Team
 Kyle Rockman,kyle@opslevel.com,Admin,platform
-Edger Ochoa,edgar@opslevel.com,Admin,platform
+Edgar Ochoa,edgar@opslevel.com,Admin,platform
 Adam Del Gobbo,adam@opslevel.com,User,sales
 EOF
 `,

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -106,19 +106,20 @@ var importUsersCmd = &cobra.Command{
 				log.Error().Err(err).Msgf("error inviting user '%s' with email '%s'", name, email)
 				continue
 			}
-			fmt.Printf("Invited user '%s' with email '%s'\n", user.Name, user.Email)
+			log.Info().Msgf("Invited user '%s' with email '%s'\n", user.Name, user.Email)
 			team := reader.Text("Team")
 			if team != "" {
-				teamResult, err := GetTeam(team)
+				t, err := GetTeam(team)
 				if err != nil {
-					log.Error().Err(err).Msgf("error finding team '%s' for user '%s'", team, email)
+					log.Error().Err(err).Msgf("error finding team '%s' for user '%s'", team, user.Email)
 					continue
 				}
-				_, err = getClientGQL().AddMember(&teamResult.TeamId, email)
+				_, err = getClientGQL().AddMember(&t.TeamId, user.Email)
 				if err != nil {
-					log.Error().Err(err).Msgf("error adding user '%s' to team '%s'", email, teamResult.Name)
+					log.Error().Err(err).Msgf("error adding user '%s' to team '%s'", user.Email, t.Name)
 					continue
 				}
+				log.Info().Msgf("added user '%s' to team '%s'", user.Email, t.Name)
 			}
 
 		}

--- a/src/common/csv.go
+++ b/src/common/csv.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// Implementation inspired from - https://stackoverflow.com/questions/24999079/reading-csv-file-in-go
+
+type CSVReader struct {
+	Reader  *csv.Reader
+	Headers map[string]int
+	Row     []string
+}
+
+func (s *CSVReader) Rows() bool {
+	record, err := s.Reader.Read()
+	s.Row = record
+	return err == nil
+}
+
+func (s *CSVReader) Text(header string) string {
+	return s.Row[s.Headers[header]]
+}
+
+func (s *CSVReader) Bool(header string) bool {
+	value, err := strconv.ParseBool(s.Text(header))
+	if err != nil {
+		return false
+	}
+	return value
+}
+
+func ReadCSVFile(filePath string) (*CSVReader, error) {
+	fileReader, err := os.Open(filePath)
+	defer fileReader.Close()
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file '%s' : %s", filePath, err)
+	}
+
+	reader := csv.NewReader(fileReader)
+	records, err2 := reader.Read()
+	if err2 != nil {
+		return nil, fmt.Errorf("failed reading file '%s' : %s", filePath, err)
+	}
+	headers := map[string]int{}
+	for i, key := range records {
+		headers[key] = i
+	}
+	output := CSVReader{Reader: reader, Headers: headers}
+	return &output, nil
+}


### PR DESCRIPTION
Add a bunch of CSV import commands that customer success has been asking for.

```
❯ opslevel import -h
Import data to OpsLevel.

Usage:
  opslevel import [command]

Available Commands:
  group       Imports groups from a CSV
  service     Imports services from a CSV
  team        Imports teams from a CSV
  user        Imports users from a CSV
```

usage examples

```
❯ cat << EOF | opslevel import user -f -
Name,Email,Role,Team
Kyle Rockman,kyle@opslevel.com,Admin,platform
Edgar Ochoa,edgar@opslevel.com,Admin,platform
Adam Del Gobbo,adam@opslevel.com,User,sales
EOF
```
and
```
❯ cat << EOF | opslevel import teams -f -
Name,Manager,Responsibilities,Group
Platform,kyle@opslevel.com,Makes Tools,engineering
Sales,john@opslevel.com,Sells Tools,product
EOF
```
and
```
❯ cat << EOF | opslevel import group -f -
Name,Description,Parent
Engineering,All of Engineering,
Product,All of Product,engineering
Sales,Sales BU,product
EOF
```
and
```
❯ cat << EOF | opslevel import services -f -
Name,Description,Product,Language,Framework,Tier,Lifecycle,Owner
Service A,,,Go,Cobra,tier_1,pre_alpha,
Service B,,,Python,Django,tier_3,beta,sales
Service C,Test,Home,,,,,platform
EOF
```