### PR TITLE
Add function to check maturity level of a service

### DIFF
--- a/.changes/unreleased/Feature-20220819-123306.yaml
+++ b/.changes/unreleased/Feature-20220819-123306.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add Rego function to check a OpsLevel service's maturity level
+time: 2022-08-19T12:33:06.083767-05:00

--- a/src/cmd/policy.go
+++ b/src/cmd/policy.go
@@ -149,7 +149,7 @@ func RegoFuncGetMaturity(ctx rego.BuiltinContext, a, b *ast.Term) (*ast.Term, er
 		return nil, err
 	}
 	client := getClientGQL()
-	service, err := client.GetServiceWithAlias(alias)
+	service, err := client.GetServiceMaturityWithAlias(alias)
 	cobra.CheckErr(err)
 	serviceLevel := service.MaturityReport.OverallLevel.Alias
 	if serviceLevel == level {

--- a/src/cmd/policy.go
+++ b/src/cmd/policy.go
@@ -148,6 +148,17 @@ func RegoFuncGetMaturity(ctx rego.BuiltinContext, a, b *ast.Term) (*ast.Term, er
 	if err := ast.As(b.Value, &level); err != nil {
 		return nil, err
 	}
+
+	if alias == "" {
+		log.Error().Msgf("opslevel.service_maturity_is(\"%s\", \"%s\") failed: Please provide a valid alias", alias, level)
+		return nil, nil
+	}
+
+	if level == "" {
+		log.Error().Msgf("opslevel.service_maturity_is(\"%s\", \"%s\") failed: Please provide a valid repo", alias, level)
+		return nil, nil
+	}
+
 	client := getClientGQL()
 	service, err := client.GetServiceMaturityWithAlias(alias)
 	cobra.CheckErr(err)

--- a/src/go.mod
+++ b/src/go.mod
@@ -73,4 +73,4 @@ require (
 )
 
 //Only used for local development!
- replace github.com/opslevel/opslevel-go/v2022 => ./submodules/opslevel-go
+replace github.com/opslevel/opslevel-go/v2022 => ./submodules/opslevel-go

--- a/src/go.mod
+++ b/src/go.mod
@@ -73,4 +73,4 @@ require (
 )
 
 //Only used for local development!
-// replace github.com/opslevel/opslevel-go/v2022 => ./submodules/opslevel-go
+ replace github.com/opslevel/opslevel-go/v2022 => ./submodules/opslevel-go


### PR DESCRIPTION
Example:
```
$ cat maturity-check.rego 
package opslevel

import future.keywords

default can_deploy_dev := false
default can_deploy_staging := false

alias := opslevel.service_maturity_level("cert-manager")["Alias"]
index := opslevel.service_maturity_level("cert-manager")["Index"]

can_deploy_dev {
    index >= 0
}

can_deploy_staging {
    alias == "silver"
}

$ go run main.go run policy -f maturity-check.rego
{"alias":"beginner","can_deploy_dev":true,"can_deploy_staging":false,"index":0}
```