### PR TITLE
Add Rego function to get gitlab project metadata

### DIFF
--- a/.changes/unreleased/Feature-20220823-105915.yaml
+++ b/.changes/unreleased/Feature-20220823-105915.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add Rego function to get Gitlab project metadata
+time: 2022-08-23T10:59:15.857458-05:00


### PR DESCRIPTION
```
$ cat gitlab-repo.rego 
package opslevel

import future.keywords

contains_value(input_list, value) {
    contains(input_list[_], value)
}

repo_name := opslevel.repo.gitlab("jklabsinc/OpsLevel")["name"]
repo_description := opslevel.repo.gitlab("jklabsinc/OpsLevel")["description"]
repo_languages := opslevel.repo.gitlab("jklabsinc/OpsLevel")["languages"]

$ go run main.go run policy -f gitlab-repo.rego                   
{"repo_description":"Source for app.opslevel.com.   Level up your DevOps teams.","repo_languages":{"CSS":1.91,"HTML+ERB":0.41,"JavaScript":26.03,"Ruby":59.17,"Vue":11.95},"repo_name":"OpsLevel"}
```