### PR TITLE
Fix single line filter exports

### DIFF
--- a/.changes/unreleased/Bugfix-20220830-104401.yaml
+++ b/.changes/unreleased/Bugfix-20220830-104401.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix bug where Terraform export was exporting single line filters as multi-line
+  strings
+time: 2022-08-30T10:44:01.499802-05:00

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -399,13 +399,11 @@ func flattenPredicate(key string, value *opslevel.Predicate) string {
 	config := `
   %s {
     type = "%s"
-    value = <<-EOT
-%s
-EOT
+    %s
   }
 `
 	if value != nil {
-		return templateConfig(config, key, value.Type, strings.ReplaceAll(value.Value, "\"", "\\\""))
+		return templateConfig(config, key, value.Type, buildMultilineStringArg("value", strings.ReplaceAll(value.Value, "\"", "\\\"")))
 	}
 	return ""
 }
@@ -416,13 +414,11 @@ func flattenFilterPredicate(value *opslevel.FilterPredicate) string {
     key = "%s"
     key_data = "%s"
     type = "%s"
-    value = <<-EOT
-%s
-EOT
+    %s
   }
 `
 	if value != nil {
-		return templateConfig(config, value.Key, value.KeyData, value.Type, value.Value)
+		return templateConfig(config, value.Key, value.KeyData, value.Type, buildMultilineStringArg("value", value.Value))
 	}
 	return ""
 }


### PR DESCRIPTION
Tested with export and got the expected predicate:
```
resource "opslevel_filter" "single_line_filter" {
  name = "Single Line Filter"
  connective = ""
  
  predicate {
    key = "language"
    key_data = ""
    type = "equals"
    value = "Kotlin"
  }

}
```