### PR TITLE
Allow tags to be deleted by ID

### DIFF
--- a/.changes/unreleased/Feature-20220908-174140.yaml
+++ b/.changes/unreleased/Feature-20220908-174140.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Allow tag deletion by ID
+time: 2022-09-08T17:41:40.1349845Z

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -228,11 +228,18 @@ var deleteServiceTagCmd = &cobra.Command{
 		if result.Id == nil {
 			cobra.CheckErr(fmt.Errorf("service '%s' not found", serviceKey))
 		}
-		for _, tag := range result.Tags.Nodes {
-			if tagKey == tag.Key || tagKey == tag.Id {
-				getClientGQL().DeleteTag(tag.Id)
-				fmt.Println("Deleted Tag")
-				common.PrettyPrint(tag)
+
+		if common.IsID(tagKey) {
+			err := getClientGQL().DeleteTag(tagKey)
+			cobra.CheckErr(err)
+			fmt.Println("Deleted Tag")
+		} else {
+			for _, tag := range result.Tags.Nodes {
+				if tagKey == tag.Key {
+					getClientGQL().DeleteTag(tag.Id)
+					fmt.Println("Deleted Tag")
+					common.PrettyPrint(tag)
+				}
 			}
 		}
 	},

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -4,9 +4,10 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
@@ -207,11 +208,11 @@ var deleteServiceCmd = &cobra.Command{
 }
 
 var deleteServiceTagCmd = &cobra.Command{
-	Use:        "tag ID|ALIAS TAG_KEY",
+	Use:        "tag ID|ALIAS TAG_KEY|TAG_ID",
 	Short:      "Delete a service's tag",
 	Long:       `Delete a service's tag'`,
 	Args:       cobra.ExactArgs(2),
-	ArgAliases: []string{"ID", "ALIAS", "TAG_KEY"},
+	ArgAliases: []string{"ID", "ALIAS", "TAG_KEY", "TAG_ID"},
 	Run: func(cmd *cobra.Command, args []string) {
 		serviceKey := args[0]
 		tagKey := args[1]
@@ -228,7 +229,7 @@ var deleteServiceTagCmd = &cobra.Command{
 			cobra.CheckErr(fmt.Errorf("service '%s' not found", serviceKey))
 		}
 		for _, tag := range result.Tags.Nodes {
-			if tagKey == tag.Key {
+			if tagKey == tag.Key || tagKey == tag.Id {
 				getClientGQL().DeleteTag(tag.Id)
 				fmt.Println("Deleted Tag")
 				common.PrettyPrint(tag)


### PR DESCRIPTION
This simple patch allows the `opslevel delete service tag` command to accept a tag id in addition to a tag name.