### PR TITLE
Add 2 features needed for “Magic Catalog”

### DIFF
--- a/.changes/unreleased/Feature-20220921-224448.yaml
+++ b/.changes/unreleased/Feature-20220921-224448.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add ability to pass arbitrary json as extra input to `run policy` command
+time: 2022-09-21T22:44:48.972438-05:00

--- a/.changes/unreleased/Feature-20220921-224514.yaml
+++ b/.changes/unreleased/Feature-20220921-224514.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add ability to output `run policy` command directly to a file
+time: 2022-09-21T22:45:14.693564-05:00

--- a/src/cmd/policy.go
+++ b/src/cmd/policy.go
@@ -21,8 +21,8 @@ import (
 )
 
 type regoInput struct {
-	Files []string `json:"files"`
-	Data  map[string]interface{}
+	Files []string               `json:"files"`
+	Data  map[string]interface{} `json:"data"`
 }
 
 type gitlabResponse struct {


### PR DESCRIPTION
This add 2 new flags to the `opslevel run policy` command

`-i ./input.json` - which allows for passing in extra JSON input for use in the policy at `input.data`

`-o ./output.json` - which allows for directly writing all policy evaluation data to a file so it doesn't get intermixed with other output from loggers

A full example would be:

```
cat << EOF > policy.rego
package opslevel
import future.keywords

value := input.data.foo.Can.nest
EOF

cat << EOF > input.json
{"foo": {"Can": {"nest": true}}}
EOF

opslevel run policy -f policy.rego -i input.json -o output.json 

cat output.json
{"value":true}
```