### PR TITLE
fix graphql command and add another example

### DIFF
--- a/src/cmd/graphql.go
+++ b/src/cmd/graphql.go
@@ -14,7 +14,7 @@ import (
     "strings"
 )
 
-var keyValueExp = regexp.MustCompile(`([\w-]+)="(.*)"`)
+var keyValueExp = regexp.MustCompile(`([\w-]+)=(.*)`)
 var usesPaginationExp = regexp.MustCompile(`\$endCursor:\WString`)
 var hasNextPageExp = regexp.MustCompile(`"hasNextPage":([\w]+)`)
 var endCursorExp = regexp.MustCompile(`"endCursor":\"([\w]+)\"`)
@@ -64,7 +64,7 @@ query ($endCursor: String) {
   }
 }'
 
-opslevel graphql -f owner="platform" -f tier="tier_1" --paginate -a=".account.services.nodes[]" -q='
+opslevel graphql -f "owner=platform" -f "tier=tier_1" --paginate -a=".account.services.nodes[]" -q='
 query ($endCursor: String, $owner: String!, $tier: String!) {
   account {
     services(first: 1, after: $endCursor, ownerAlias: $owner, tierAlias: $tier) {
@@ -79,6 +79,15 @@ query ($endCursor: String, $owner: String!, $tier: String!) {
     }
   }
 }'
+
+opslevel graphql -f "id=XXXXXX" -H "GraphQL-Visibility=internal" -a=".account.configFile.yaml" -q='
+query ($id: ID!){
+  account {
+    configFile(id: $id) {
+      yaml
+    }
+  }
+}' | jq -r '.[0]' > opslevel.yml
 `,
     Run: func(cmd *cobra.Command, args []string) {
         flags := cmd.Flags()


### PR DESCRIPTION
after doing some more testing i found a bug with key=value parsing and this change makes it make the most sense.

I also added a really cool example of showing how to use the internal API to download the opslevel.yml file for a service