### PR TITLE
Fix panic when paginating on empty GQL response

### DIFF
--- a/src/cmd/graphql.go
+++ b/src/cmd/graphql.go
@@ -142,7 +142,10 @@ query ($id: ID!){
 			if paginate {
 				hasNextPage, err = strconv.ParseBool(string(hasNextPageExp.FindSubmatch(data)[1]))
 				handleErr("error parsing bool for has next page", err)
-				variables["endCursor"] = string(endCursorExp.FindSubmatch(data)[1])
+				// don't try to parse endCursor unless we know there's another page
+				if hasNextPage {
+					variables["endCursor"] = string(endCursorExp.FindSubmatch(data)[1])
+				}
 			} else {
 				hasNextPage = false
 			}


### PR DESCRIPTION
Fixes a panic (see #126) in `opslevel graphql` when you attempt to paginate over a response with `"endCursor": null`. This can be triggered with the following script (assuming there's no team with alias `"does-not-exist"`):

    #!/bin/bash

    QUERY='query($endCursor: String) {
        account {
            services(ownerAlias: "does-not-exist", after: $endCursor) {
                pageInfo {
                    endCursor
                    hasNextPage
                }
                nodes {
                    name
                }
            }
        }
    }'

    opslevel graphql --paginate --query "$QUERY"

Sample panic from running that script before this change:

    $ OPSLEVEL_API_TOKEN=<redacted> ./script
    panic: runtime error: index out of range [1] with length 0

    goroutine 1 [running]:
    github.com/opslevel/cli/cmd.glob..func21(0x17c9400?, {0xf6e323?, 0x3?, 0x3?})
            /home/user/src/opslevel-cli/src/cmd/graphql.go:145 +0xb0c
    github.com/spf13/cobra.(*Command).execute(0x17c9400, {0xc0002a2720, 0x3, 0x3})
            /home/user/.local/share/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x847
    github.com/spf13/cobra.(*Command).ExecuteC(0x17bf300)
            /home/user/.local/share/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
    github.com/spf13/cobra.(*Command).Execute(...)
            /home/user/.local/share/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
    github.com/opslevel/cli/cmd.Execute({0xf6d94e?, 0x0?}, {0xdf7f00?, 0xc0000061a0?})
            /home/user/src/opslevel-cli/src/cmd/root.go:29 +0x4a
    main.main()
            /home/user/src/opslevel-cli/src/main.go:13 +0x35