### PR TITLE
PrettyPrint no longer escapes html

### DIFF
--- a/.changes/unreleased/Bugfix-20230619-172139.yaml
+++ b/.changes/unreleased/Bugfix-20230619-172139.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: PrettyPrint no longer escapes html
+time: 2023-06-19T17:21:39.366408-04:00

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/creasty/defaults"

--- a/src/common/output.go
+++ b/src/common/output.go
@@ -1,20 +1,26 @@
 package common
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/viper"
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/spf13/viper"
 
 	"github.com/spf13/cobra"
 )
 
 func PrettyPrint(object interface{}) {
-	bytes, err := json.MarshalIndent(object, "", "  ")
+	var b bytes.Buffer
+	jsonEncoder := json.NewEncoder(&b)
+	jsonEncoder.SetEscapeHTML(false)
+	jsonEncoder.SetIndent("", " ")
+	err := jsonEncoder.Encode(&object)
 	cobra.CheckErr(err)
-	fmt.Println(string(bytes))
+	fmt.Println(string(b.Bytes()))
 }
 
 func NewTabWriter(headers ...string) *tabwriter.Writer {

--- a/src/common/output.go
+++ b/src/common/output.go
@@ -17,7 +17,7 @@ func PrettyPrint(object interface{}) {
 	var b bytes.Buffer
 	jsonEncoder := json.NewEncoder(&b)
 	jsonEncoder.SetEscapeHTML(false)
-	jsonEncoder.SetIndent("", " ")
+	jsonEncoder.SetIndent("", "  ")
 	err := jsonEncoder.Encode(&object)
 	cobra.CheckErr(err)
 	fmt.Println(string(b.Bytes()))

--- a/src/common/output_test.go
+++ b/src/common/output_test.go
@@ -1,0 +1,33 @@
+package common_test
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	common "github.com/opslevel/cli/common"
+	"github.com/rocktavious/autopilot"
+)
+
+func captureOutput() string {
+	stdOut := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	common.PrettyPrint("< > & alan was here & < >")
+
+	w.Close()
+	out, _ := ioutil.ReadAll(r)
+	os.Stdout = stdOut
+
+	return string(out)
+}
+
+func TestPrettyPrint(t *testing.T) {
+	// Arrange
+	trimmedTestString := strings.TrimRight(captureOutput(), "\n") // captureOuput adds an extra newline
+	// Act
+	// Assert
+	autopilot.Equals(t, "\"< > & alan was here & < >\"", trimmedTestString)
+}


### PR DESCRIPTION
- create `json.Encoder` to customize `SetEscapeHTML` and `SetIndent` to print `rawNotes` without escaping these following chars:
  - "<", ">", "&", U+2028, and U+2029 are escaped to "\u003c","\u003e", "\u0026", "\u2028", and "\u2029"

this misbehaviour was discovered during investigation from this [ticket](https://gitlab.com/jklabsinc/OpsLevel/-/issues/7693)