### PR TITLE
add golangci task, fix linter found issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+run:
+  timeout: 2m
+linters:
+  disable:
+      # 1st -> remove staticcheck and fix lint issues
+    - staticcheck
+      # 2nd -> remove errcheck and ineffassign
+    - errcheck
+    - ineffassign

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,16 +9,14 @@ tasks:
     cmds:
       - gofmt -d .
       - go vet ./...
-      # TODO: uncomment after lint fixes addressed
-      # - golangci-lint run
+      - golangci-lint run
 
   lintfix:
     desc: Fix formatting and linting
     dir: src
     cmds:
       - gofmt -w .
-      # TODO: uncomment after lint fixes addressed
-      # - golangci-lint run --fix
+      - golangci-lint run --fix
 
   test:
     desc: Run tests

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/opslevel/opslevel-go/v2023"
@@ -62,7 +61,7 @@ Examples:
 	opslevel create check -f my_cec.yaml
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		usePrompts := hasStdin() == false
+		usePrompts := !hasStdin()
 		input, err := readCheckCreateInput()
 		cobra.CheckErr(err)
 		check, err := createCheck(*input, usePrompts)
@@ -488,7 +487,7 @@ func readCheckCreateInput() (*CheckCreateType, error) {
 	v := &ConfigVersion{}
 	viper.Unmarshal(&v)
 	if v.Version != CheckConfigCurrentVersion {
-		return nil, errors.New(fmt.Sprintf("Supported config version is '%s' but found '%s' | Please update config file", CheckConfigCurrentVersion, v.Version))
+		return nil, fmt.Errorf("Supported config version is '%s' but found '%s' | Please update config file", CheckConfigCurrentVersion, v.Version)
 	}
 	// Unmarshall
 	evt := &CheckCreateType{}

--- a/src/cmd/graphql.go
+++ b/src/cmd/graphql.go
@@ -4,20 +4,22 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/itchyny/gojq"
-	"github.com/opslevel/opslevel-go/v2023"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/itchyny/gojq"
+	"github.com/opslevel/opslevel-go/v2023"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
-var keyValueExp = regexp.MustCompile(`([\w-]+)=(.*)`)
-var usesPaginationExp = regexp.MustCompile(`\$endCursor:\WString`)
-var hasNextPageExp = regexp.MustCompile(`"hasNextPage":([\w]+)`)
-var endCursorExp = regexp.MustCompile(`"endCursor":\"([\w]+)\"`)
+var (
+	keyValueExp    = regexp.MustCompile(`([\w-]+)=(.*)`)
+	hasNextPageExp = regexp.MustCompile(`"hasNextPage":([\w]+)`)
+	endCursorExp   = regexp.MustCompile(`"endCursor":\"([\w]+)\"`)
+)
 
 // graphqlCmd represents the graphql command
 var graphqlCmd = &cobra.Command{
@@ -135,9 +137,7 @@ query ($id: ID!){
 		for hasNextPage {
 			data, err := client.ExecRaw(query, variables, opslevel.WithName(operationName))
 			handleErr("error making graphql api call", err)
-			for _, item := range handleAggregate(data, aggregation) {
-				output = append(output, item)
-			}
+			output = append(output, handleAggregate(data, aggregation)...)
 
 			if paginate {
 				hasNextPage, err = strconv.ParseBool(string(hasNextPageExp.FindSubmatch(data)[1]))

--- a/src/cmd/policy.go
+++ b/src/cmd/policy.go
@@ -5,6 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"math"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/types"
@@ -13,12 +20,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io/ioutil"
-	"math"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type regoInput struct {
@@ -184,7 +185,7 @@ Examples:
 		)
 		rs, err := rego.Eval(context.Background())
 		cobra.CheckErr(err)
-		b, err := json.Marshal(rs[0].Expressions[0].Value) //TODO: need more advanced handling of multiple things in json and reading from stdin
+		b, err := json.Marshal(rs[0].Expressions[0].Value) // TODO: need more advanced handling of multiple things in json and reading from stdin
 		cobra.CheckErr(err)
 
 		if outputFilePath == "-" {
@@ -221,7 +222,6 @@ func RegoFuncReadFile(ctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
 }
 
 func RegoFuncGetGithubRepo(ctx rego.BuiltinContext, a, b *ast.Term) (*ast.Term, error) {
-
 	var org, repo string
 	if err := ast.As(a.Value, &org); err != nil {
 		log.Error().Err(err).Msg("")
@@ -260,7 +260,7 @@ func RegoFuncGetGithubRepo(ctx rego.BuiltinContext, a, b *ast.Term) (*ast.Term, 
 		return nil, err
 	}
 
-	if response.IsError() == true {
+	if response.IsError() {
 		err := fmt.Errorf("error requesting Github repo metadata. CODE: %d: REASON: %s", response.StatusCode(), response)
 		log.Error().Err(err).Msgf("")
 		return nil, err
@@ -276,7 +276,7 @@ func RegoFuncGetGithubRepo(ctx rego.BuiltinContext, a, b *ast.Term) (*ast.Term, 
 		return nil, err
 	}
 
-	if languagesResponse.IsError() == true {
+	if languagesResponse.IsError() {
 		err := fmt.Errorf("error requesting Github repo languages. CODE: %d: REASON: %s", response.StatusCode(), response)
 		log.Error().Err(err).Msgf("")
 		return nil, err
@@ -294,7 +294,6 @@ func RegoFuncGetGithubRepo(ctx rego.BuiltinContext, a, b *ast.Term) (*ast.Term, 
 }
 
 func RegoFuncGetGitlabRepo(ctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
-
 	var path string
 	if err := ast.As(a.Value, &path); err != nil {
 		log.Error().Err(err).Msg("")
@@ -322,7 +321,7 @@ func RegoFuncGetGitlabRepo(ctx rego.BuiltinContext, a *ast.Term) (*ast.Term, err
 		return nil, err
 	}
 
-	if response.IsError() == true {
+	if response.IsError() {
 		err := fmt.Errorf("error requesting Gitlab repo metadata. CODE: %d: REASON: %s", response.StatusCode(), response)
 		log.Error().Err(err).Msgf("")
 		return nil, err
@@ -337,7 +336,7 @@ func RegoFuncGetGitlabRepo(ctx rego.BuiltinContext, a *ast.Term) (*ast.Term, err
 		return nil, err
 	}
 
-	if languagesResponse.IsError() == true {
+	if languagesResponse.IsError() {
 		err := fmt.Errorf("error requesting Gitlab repo languages. CODE: %d: REASON: %s", response.StatusCode(), response)
 		log.Error().Err(err).Msgf("")
 		return nil, err
@@ -354,7 +353,6 @@ func RegoFuncGetGitlabRepo(ctx rego.BuiltinContext, a *ast.Term) (*ast.Term, err
 }
 
 func RegoFuncGetMaturity(ctx rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
-
 	var alias string
 	if err := ast.As(a.Value, &alias); err != nil {
 		log.Error().Err(err).Msg("")

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -4,9 +4,10 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"github.com/opslevel/opslevel-go/v2023"
 	"os"
 	"strings"
+
+	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/rs/zerolog/log"
 
@@ -43,7 +44,7 @@ var createServiceTagCmd = &cobra.Command{
 	Use:   "tag ID|ALIAS TAG_KEY TAG_VALUE",
 	Short: "Create a service tag",
 	Long: `Create a service tag
-	
+
 opslevel create service tag my-service foo bar
 opslevel create service tag --assign my-service foo bar
 `,
@@ -140,7 +141,7 @@ opslevel get service tag my-service my-tag
 		}
 		var output []opslevel.Tag
 		for _, tag := range result.Tags.Nodes {
-			if singleTag == false || tagKey == tag.Key {
+			if !singleTag || tagKey == tag.Key {
 				output = append(output, tag)
 			}
 		}

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/creasty/defaults"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/rs/zerolog/log"
@@ -62,43 +63,45 @@ var createMemberCmd = &cobra.Command{
 	},
 }
 
-var contactType string
-var createContactCmd = &cobra.Command{
-	Use:   "contact {TEAM_ID|TEAM_ALIAS} ADDRESS DISPLAYNAME",
-	Short: "Add a contact to a team",
-	Example: `opslevel create contact --type=slack my-team #general General
+var (
+	contactType      string
+	createContactCmd = &cobra.Command{
+		Use:   "contact {TEAM_ID|TEAM_ALIAS} ADDRESS DISPLAYNAME",
+		Short: "Add a contact to a team",
+		Example: `opslevel create contact --type=slack my-team #general General
 opslevel create contact --type=email my-team team@example.com "Mailing List"`,
-	Args:       cobra.MinimumNArgs(2),
-	ArgAliases: []string{"TEAM_ID", "TEAM_ALIAS", "ADDRESS", "DISPLAYNAME"},
-	Run: func(cmd *cobra.Command, args []string) {
-		key := args[0]
-		address := args[1]
-		displayName := common.GetArg(args, 2, "")
+		Args:       cobra.MinimumNArgs(2),
+		ArgAliases: []string{"TEAM_ID", "TEAM_ALIAS", "ADDRESS", "DISPLAYNAME"},
+		Run: func(cmd *cobra.Command, args []string) {
+			key := args[0]
+			address := args[1]
+			displayName := common.GetArg(args, 2, "")
 
-		var team *opslevel.Team
-		var err error
-		if common.IsID(key) {
-			team, err = getClientGQL().GetTeam(opslevel.ID(key))
-		} else {
-			team, err = getClientGQL().GetTeamWithAlias(key)
-		}
-		cobra.CheckErr(err)
-		common.WasFound(team.Id == "", key)
-		contactInput := opslevel.CreateContactSlack(address, displayName)
-		switch contactType {
-		case string(opslevel.ContactTypeEmail):
-			contactInput = opslevel.CreateContactEmail(address, displayName)
-		case string(opslevel.ContactTypeWeb):
-			contactInput = opslevel.CreateContactWeb(address, displayName)
-		}
-		contact, err := getClientGQL().AddContact(team.TeamId.Alias, contactInput)
-		cobra.CheckErr(err)
-		if contact.Id == "" {
-			cobra.CheckErr(fmt.Errorf("unable to create contact '%+v'", contactInput))
-		}
-		fmt.Printf("create contact '%+v' on team '%s'\n", contactInput, team.Alias)
-	},
-}
+			var team *opslevel.Team
+			var err error
+			if common.IsID(key) {
+				team, err = getClientGQL().GetTeam(opslevel.ID(key))
+			} else {
+				team, err = getClientGQL().GetTeamWithAlias(key)
+			}
+			cobra.CheckErr(err)
+			common.WasFound(team.Id == "", key)
+			contactInput := opslevel.CreateContactSlack(address, displayName)
+			switch contactType {
+			case string(opslevel.ContactTypeEmail):
+				contactInput = opslevel.CreateContactEmail(address, displayName)
+			case string(opslevel.ContactTypeWeb):
+				contactInput = opslevel.CreateContactWeb(address, displayName)
+			}
+			contact, err := getClientGQL().AddContact(team.TeamId.Alias, contactInput)
+			cobra.CheckErr(err)
+			if contact.Id == "" {
+				cobra.CheckErr(fmt.Errorf("unable to create contact '%+v'", contactInput))
+			}
+			fmt.Printf("create contact '%+v' on team '%s'\n", contactInput, team.Alias)
+		},
+	}
+)
 
 var createTeamTagCmd = &cobra.Command{
 	Use:   "tag {ID|ALIAS} TAG_KEY TAG_VALUE",
@@ -194,7 +197,7 @@ var listTeamCmd = &cobra.Command{
 	Short:   "Lists the teams",
 	Example: `
 opslevel list team
-opslevel list team -o json | jq 'map((.Members.Nodes | map(.Email)))' 
+opslevel list team -o json | jq 'map((.Members.Nodes | map(.Email)))'
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		resp, err := getClientGQL().ListTeams(nil)
@@ -243,7 +246,7 @@ opslevel get team tag my-team | jq 'from_entries'
 		}
 		var output []opslevel.Tag
 		for _, tag := range result.Tags.Nodes {
-			if singleTag == false || tagKey == tag.Key {
+			if !singleTag || tagKey == tag.Key {
 				output = append(output, tag)
 			}
 		}

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/opslevel/opslevel-go/v2023"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/gosimple/slug"
 	"github.com/spf13/cobra"
@@ -27,21 +28,19 @@ func init() {
 }
 
 func newFile(filename string, makeExecutable bool) *os.File {
-	path := fmt.Sprintf("%s", filename)
-
-	var _, err = os.Stat(path)
+	_, err := os.Stat(filename)
 	if os.IsExist(err) {
-		removeErr := os.Remove(path)
+		removeErr := os.Remove(filename)
 		if removeErr != nil {
 			panic(removeErr)
 		}
 	}
-	file, err := os.Create(path)
+	file, err := os.Create(filename)
 	if err != nil {
 		panic(err)
 	}
 	if makeExecutable {
-		if err := os.Chmod(path, 0755); err != nil {
+		if err := os.Chmod(filename, 0755); err != nil {
 			panic(err)
 		}
 	}
@@ -50,7 +49,7 @@ func newFile(filename string, makeExecutable bool) *os.File {
 
 func templateConfig(tmpl string, a ...interface{}) string {
 	// TODO: it would be nice to remove blank lines to condense the terraform config - this is a hacky way that doesn't work
-	//return strings.ReplaceAll(fmt.Sprintf(tmpl, a...), "  \n", "")
+	// return strings.ReplaceAll(fmt.Sprintf(tmpl, a...), "  \n", "")
 	return fmt.Sprintf(tmpl, a...)
 }
 
@@ -112,7 +111,7 @@ provider "opslevel" {
 // we would likely need to tie the resource's ID to the generated string for future lookups for connected resources
 func makeTerraformSlug(value string) string {
 	return strings.ReplaceAll(slug.Make(value), "-", "_")
-	//return strings.ReplaceAll(strings.ReplaceAll(slug.Make(value), "-", "_"), ":", "_")
+	// return strings.ReplaceAll(strings.ReplaceAll(slug.Make(value), "-", "_"), ":", "_")
 }
 
 func getIntegrationTerraformName(integration opslevel.IntegrationId) string {

--- a/src/common/helpers.go
+++ b/src/common/helpers.go
@@ -43,7 +43,7 @@ func YamlPrint(object interface{}) {
 	yamlEncoder.SetIndent(4) // this is what you're looking for
 	err := yamlEncoder.Encode(&object)
 	cobra.CheckErr(err)
-	fmt.Printf("---\n%s\n", string(b.Bytes()))
+	fmt.Printf("---\n%s\n", b.String())
 }
 
 func MinInt(values ...int) int {

--- a/src/common/output.go
+++ b/src/common/output.go
@@ -20,7 +20,7 @@ func PrettyPrint(object interface{}) {
 	jsonEncoder.SetIndent("", "  ")
 	err := jsonEncoder.Encode(&object)
 	cobra.CheckErr(err)
-	fmt.Println(string(b.Bytes()))
+	fmt.Println(b.String())
 }
 
 func NewTabWriter(headers ...string) *tabwriter.Writer {
@@ -37,7 +37,7 @@ func NewTabWriter(headers ...string) *tabwriter.Writer {
 	}
 	headerFormat.WriteString("\n")
 	w := tabwriter.NewWriter(os.Stdout, longestHeader, longestHeader, 2, ' ', 0)
-	if viper.GetBool("no-headers") == false {
+	if !viper.GetBool("no-headers") {
 		fmt.Fprintf(w, headerFormat.String(), headersCasted...)
 	}
 	return w

--- a/src/common/output_test.go
+++ b/src/common/output_test.go
@@ -1,7 +1,7 @@
 package common_test
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -18,7 +18,7 @@ func captureOutput() string {
 	common.PrettyPrint("< > & alan was here & < >")
 
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stdout = stdOut
 
 	return string(out)


### PR DESCRIPTION
Add running `golangci-lint run` to `task lint`.
Add `.golangci.yml` to temporarily ignore some linter's raised issues.
Address issues raised by other linters in aggregate [golang-ci](https://golangci-lint.run/)