### PR TITLE
Bugfix for reading YAML files on update

### DIFF
--- a/.changes/unreleased/Bugfix-20230726-195424.yaml
+++ b/.changes/unreleased/Bugfix-20230726-195424.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug when updating a resource using a yaml file
+time: 2023-07-26T19:54:24.648699-04:00

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -482,7 +482,7 @@ type ConfigVersion struct {
 }
 
 func readCheckCreateInput() (*CheckCreateType, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	// Validate Version
 	v := &ConfigVersion{}
 	viper.Unmarshal(&v)

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -1,14 +1,9 @@
 package cmd
 
 import (
-	"io"
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-var createDataFile string
 
 var createCmd = &cobra.Command{
 	Use:   "create",
@@ -19,61 +14,6 @@ var createCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(createCmd)
 
-	createCmd.PersistentFlags().StringVarP(&createDataFile, "file", "f", "-", "File to read data from. If '.' then reads from './data.yaml'. Defaults to reading from stdin.")
+	createCmd.PersistentFlags().StringVarP(&dataFile, "file", "f", "-", "File to read data from. If '.' then reads from './data.yaml'. Defaults to reading from stdin.")
 	viper.BindPFlags(createCmd.Flags())
-}
-
-func hasStdin() bool {
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return stat.Size() > 0
-}
-
-func readCreateFile() ([]byte, error) {
-	if hasStdin() {
-		data, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return nil, err
-		}
-		return data, nil
-	} else {
-		file, err := os.Open(createDataFile)
-		if err != nil {
-			return nil, err
-		}
-		defer file.Close()
-
-		data, err := io.ReadAll(file)
-		if err != nil {
-			return nil, err
-		}
-		return data, nil
-	}
-}
-
-func readCreateConfigFile() {
-	if createDataFile != "" {
-		if createDataFile == "-" {
-			viper.SetConfigType("yaml")
-			if hasStdin() {
-				viper.ReadConfig(os.Stdin)
-			}
-			return
-		} else if createDataFile == "." {
-			viper.SetConfigFile("./data.yaml")
-		} else {
-			viper.SetConfigFile(createDataFile)
-		}
-	} else {
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		viper.SetConfigName("data")
-		viper.SetConfigType("yaml")
-		viper.AddConfigPath(".")
-		viper.AddConfigPath(home)
-	}
-	viper.ReadInConfig()
 }

--- a/src/cmd/dependency.go
+++ b/src/cmd/dependency.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -57,7 +58,7 @@ func init() {
 }
 
 func readCreateServiceDependencyInput() (*opslevel.ServiceDependencyCreateInput, error) {
-	data, err := readCreateFile()
+	data, err := readInputFile()
 	if err != nil {
 		return nil, err
 	}

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"encoding/json"
-	"github.com/opslevel/opslevel-go/v2023"
 	"os"
 	"time"
+
+	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/creasty/defaults"
 	git "github.com/go-git/go-git/v5"
@@ -115,7 +116,7 @@ func init() {
 }
 
 func readCreateConfigAsDeployEvent() (*DeployEvent, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	evt := &DeployEvent{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {

--- a/src/cmd/document.go
+++ b/src/cmd/document.go
@@ -30,7 +30,7 @@ opslevel create document my-service -r services -t openapi -i xxxxx -f swagger.j
 		integrationID, err := flags.GetString("integration-id")
 		cobra.CheckErr(err)
 		integrationURL := fmt.Sprintf("integrations/document/%s/%s/%s/%s", integrationID, resourceType, serviceAlias, documentType)
-		fileContents, err := os.ReadFile(createDataFile)
+		fileContents, err := os.ReadFile(dataFile)
 		cobra.CheckErr(err)
 		var result opslevel.RestResponse
 		response, err := getClientRest().R().

--- a/src/cmd/domain.go
+++ b/src/cmd/domain.go
@@ -4,13 +4,14 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"strings"
 )
 
 var createDomainCmd = &cobra.Command{
@@ -138,7 +139,7 @@ func init() {
 }
 
 func readDomainInput() (*opslevel.DomainInput, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	evt := &opslevel.DomainInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -344,7 +344,7 @@ func init() {
 }
 
 func readGroupInput() (*opslevel.GroupInput, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	evt := &opslevel.GroupInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {

--- a/src/cmd/input.go
+++ b/src/cmd/input.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var dataFile string
+
+func hasStdin() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return stat.Size() > 0
+}
+
+func readInputFile() ([]byte, error) {
+	if hasStdin() {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
+	} else {
+		file, err := os.Open(dataFile)
+		if err != nil {
+			return nil, err
+		}
+		defer file.Close()
+
+		data, err := io.ReadAll(file)
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+}
+
+func readInputConfig() {
+	if dataFile != "" {
+		if dataFile == "-" {
+			viper.SetConfigType("yaml")
+			if hasStdin() {
+				viper.ReadConfig(os.Stdin)
+			}
+			return
+		} else if dataFile == "." {
+			viper.SetConfigFile("./data.yaml")
+		} else {
+			viper.SetConfigFile(dataFile)
+		}
+	} else {
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		viper.SetConfigName("data")
+		viper.SetConfigType("yaml")
+		viper.AddConfigPath(".")
+		viper.AddConfigPath(home)
+	}
+	viper.ReadInConfig()
+}

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -338,7 +338,7 @@ func init() {
 }
 
 func readServiceCreateInput() (*opslevel.ServiceCreateInput, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	evt := &opslevel.ServiceCreateInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {
@@ -348,7 +348,7 @@ func readServiceCreateInput() (*opslevel.ServiceCreateInput, error) {
 }
 
 func readServiceUpdateInput() (*opslevel.ServiceUpdateInput, error) {
-	readUpdateConfigFile()
+	readInputConfig()
 	evt := &opslevel.ServiceUpdateInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {

--- a/src/cmd/system.go
+++ b/src/cmd/system.go
@@ -4,13 +4,14 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"strings"
 )
 
 var createSystemCmd = &cobra.Command{
@@ -139,7 +140,7 @@ func init() {
 }
 
 func readSystemInput() (*opslevel.SystemInput, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	evt := &opslevel.SystemInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -413,7 +413,7 @@ func init() {
 }
 
 func readTeamCreateInput() (*opslevel.TeamCreateInput, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	evt := &opslevel.TeamCreateInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {
@@ -423,7 +423,7 @@ func readTeamCreateInput() (*opslevel.TeamCreateInput, error) {
 }
 
 func readTeamUpdateInput() (*opslevel.TeamUpdateInput, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	evt := &opslevel.TeamUpdateInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -1,46 +1,19 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var updateDataFile string
-
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Update resources in OpsLevel",
-	Long:  "Update resources in OpsLevel",
+	Short: "Update resources or events from a file or stdin",
+	Long:  "Update resources or events from a file or stdin",
 }
 
 func init() {
 	rootCmd.AddCommand(updateCmd)
 
-	updateCmd.PersistentFlags().StringVarP(&updateDataFile, "file", "f", "-", "File to read update from. If '.' then reads from './data.yaml'. Defaults to reading from stdin.")
-	viper.BindPFlags(createCmd.Flags())
-}
-
-func readUpdateConfigFile() {
-	if updateDataFile != "" {
-		if updateDataFile == "-" {
-			viper.SetConfigType("yaml")
-			viper.ReadConfig(os.Stdin)
-			return
-		} else if updateDataFile == "." {
-			viper.SetConfigFile("./data.yaml")
-		} else {
-			viper.SetConfigFile(updateDataFile)
-		}
-	} else {
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		viper.SetConfigName("data")
-		viper.SetConfigType("yaml")
-		viper.AddConfigPath(".")
-		viper.AddConfigPath(home)
-	}
-	viper.ReadInConfig()
+	updateCmd.PersistentFlags().StringVarP(&dataFile, "file", "f", "-", "File to read update from. If '.' then reads from './data.yaml'. Defaults to reading from stdin.")
+	viper.BindPFlags(updateCmd.Flags())
 }

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -4,15 +4,16 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
+
 	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"sort"
-	"strings"
 )
 
 var createUserCmd = &cobra.Command{
@@ -211,7 +212,7 @@ func init() {
 }
 
 func readUserInput() (*opslevel.UserInput, error) {
-	readCreateConfigFile()
+	readInputConfig()
 	evt := &opslevel.UserInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {


### PR DESCRIPTION
Blocks https://github.com/OpsLevel/cli/pull/139

## Problem

Bug: `opslevel update $RESOURCE -f $CONFIG.yaml` will not read the input YAML file, unless you pass `-`. This happens for resources like `domains` which don't have a separate input file reading function call. [See example in domain.go](https://github.com/OpsLevel/cli/blob/842ae0260021d1bfc45ba5e63282749a29806c77/src/cmd/domain.go#L141) where creating a domain using a YAML file works but updating one does not.

`-f -` (stdin) is able to work because of persistent flags set in [create.go](https://github.com/OpsLevel/cli/blob/842ae0260021d1bfc45ba5e63282749a29806c77/src/cmd/create.go#L22) and [update.go.](https://github.com/OpsLevel/cli/blob/842ae0260021d1bfc45ba5e63282749a29806c77/src/cmd/update.go#L21)

## Solution

Merge file reading functions from create.go and update.go into input.go, share `dataFile` variable between them.

## Tophatting

Setup: I added these 2 lines before the graphql calls in domain.go and created a file called create_domain.yaml and update_domain.yaml.

```
fmt.Printf("%s\n%s\n%s\n%s\n", *input.Description, *input.Name, *input.Note, *input.Owner)
os.Exit(1)
```

Can read yaml input for create:

```
$ go run main.go create domain -f create_domain.yaml
Hello World Domain
My Domain
Additional details
Z2lkOi8vb3BzbGV2ZWwvVGVhbS83NjY
```

Can read yaml input for update:

```
$ go run main.go update domain reddit.com -f update_domain.yaml
Updated Hello World Domain
My Updated Domain
This was updated
Z2lkOi8vb3BzbGV2ZWwvVGVhbS83NjY
```