### PR TITLE
Remove stdin check when reading YAML input

### DIFF
--- a/.changes/unreleased/Bugfix-20230801-165131.yaml
+++ b/.changes/unreleased/Bugfix-20230801-165131.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix inability to read YAML from stdin in containers
+time: 2023-08-01T16:51:31.147078-04:00

--- a/src/cmd/input.go
+++ b/src/cmd/input.go
@@ -44,10 +44,7 @@ func readInputConfig() {
 	if dataFile != "" {
 		if dataFile == "-" {
 			viper.SetConfigType("yaml")
-			if hasStdin() {
-				viper.ReadConfig(os.Stdin)
-			}
-			return
+			viper.ReadConfig(os.Stdin)
 		} else if dataFile == "." {
 			viper.SetConfigFile("./data.yaml")
 		} else {


### PR DESCRIPTION
## Problem

The `hasStdIn()` call evaluates to `true` on macOS but `false` in Linux containers. It's not clear why this happens, but logically speaking if the user passed `-f -` they want to read from `stdin`, so it's not necessary to check for it in this case.

As a result, trying to create any resource using a heredoc and YAML will either fail or result in a weird request being sent to the server where none of the intended data was sent. This happens when using containers, or at least the Docker container we have for CLI.

Previously we didn't have this bug happen during `update` operations because they didn't include this check. Only `create` operations were affected. [Source Code](https://github.com/OpsLevel/cli/pull/141/files#diff-f7a74bdb21647930a3ab58b74971361aeb9c65bac68220b6847175119795c646L27)

## Solution

Remove the function call from `readInputConfig()`.

## Tophatting

I used the existing Dockerfile to create a local container for the CLI called `testing`. I also created a 2nd Dockerfile to attempt to create a `deploy` to see if YAML can be parsed from `stdin`.

```
$ cd src
$ env GOOS=linux GOARCH=arm64 go build -o opslevel
$ go build -t testing -f Dockerfile .
$ cat Dockerfile2
FROM testing
ENTRYPOINT ["/entrypoint.sh"]
COPY entrypoint.sh /entrypoint.sh%
$ cat entrypoint.sh
#!/bin/bash
cat << EOF | opslevel --log-level DEBUG create deploy -i "INTEGRATION_URL" --dry-run -f -
service: "SOME_SERVICE"
EOF%
$ docker run test
9:01PM DBG does not have stdin!!!
9:01PM INF {"service":"SOME_SERVICE","deployer":{"email":"automation@opslevel.com"},"deployed_at":"2023-08-01T21:01:41.437024791Z","description":"Event Created by OpsLevel CLI","commit":{}}
```

The line `does not have stdin!!!` is from a debug statement I was using.