### PR TITLE
Db/add workspace task

### DIFF
--- a/.changes/unreleased/Feature-20230808-152948.yaml
+++ b/.changes/unreleased/Feature-20230808-152948.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add task workflow for tandem opslevel-go dev
+time: 2023-08-08T15:29:48.516822-05:00

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: '1.20'
       - name: Run Tests
         run: |-
-          cd src/
-          go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+          task workspace
+          task testcov
       - name: Upload Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.20'
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Tests
         run: |-
           task workspace

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 src/dist
 .idea
 .DS_Store
+go.work*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,7 @@ This way you can iterate on the CLI code quickly to test out your new functional
 
 #### Local Development with an `opslevel-go` Feature Branch
 
-Sometimes you may want to test your local code against a feature branch in the
-`OpsLevel` repository. To do this, run:
+To test local code against a feature branch in the `opslevel-go` repository, run:
 
 ```sh
 # initializes opslevel-go submodule then sets up src/go.work
@@ -83,7 +82,7 @@ task workspace
 git -C ./src/submodules/opslevel-go checkout --track origin/my-feature-branch
 ```
 
-Now code imported from `github.com/opslevel/opslevel-go` will be sourced from the
+Code imported from `github.com/opslevel/opslevel-go` will now be sourced from the
 local `my-feature-branch`.
 
 ### Changie (Change log generation)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,22 @@ go run main.go -h
 
 This way you can iterate on the CLI code quickly to test out your new functionality.
 
+#### Local Development with an `opslevel-go` Feature Branch
+
+Sometimes you may want to test your local code against a feature branch in the
+`OpsLevel` repository. To do this, run:
+
+```sh
+# initializes opslevel-go submodule then sets up src/go.work
+task workspace
+
+# git checkouts my-feature-branch in the src/submodules/opslevel-go directory
+git -C ./src/submodules/opslevel-go checkout --track origin/my-feature-branch
+```
+
+Now code imported from `github.com/opslevel/opslevel-go` will be sourced from the
+local `my-feature-branch`.
+
 ### Changie (Change log generation)
 
 Before submitting the pull request, you need add a change entry via Changie so that your contribution changes can be tracked for our next release.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,10 +2,13 @@
 
 version: '3'
 
+env:
+  SRC_DIR: "{{.TASKFILE_DIR}}/src"
+
 tasks:
   lint:
     desc: Formatting and linting
-    dir: src
+    dir: "{{.SRC_DIR}}"
     cmds:
       - gofmt -d .
       - go vet ./...
@@ -13,7 +16,7 @@ tasks:
 
   lintfix:
     desc: Fix formatting and linting
-    dir: src
+    dir: "{{.SRC_DIR}}"
     cmds:
       - gofmt -w .
       - go mod tidy
@@ -21,7 +24,17 @@ tasks:
 
   test:
     desc: Run tests
-    dir: src
+    dir: "{{.SRC_DIR}}"
     cmds:
       - go test -v ./... {{ .CLI_ARGS }}
     silent: true
+
+  workspace:
+    desc: Setup workspace for local opslevel-go development
+    dir: "{{.SRC_DIR}}"
+    cmds:
+      - git submodule update --init
+        # The ":" is a no-op that keeps things rolling
+      - go work init || ":"
+      - go work use . submodules/opslevel-go
+      - echo "Workspace ready!"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -29,8 +29,14 @@ tasks:
       - go test -v ./... {{ .CLI_ARGS }}
     silent: true
 
+  testcov:
+    desc: Run tests with code coverage output
+    dir: "{{.SRC_DIR}}"
+    cmds:
+      - go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+
   workspace:
-    desc: Setup workspace for local opslevel-go development
+    desc: Setup workspace for cli & opslevel-go development
     dir: "{{.SRC_DIR}}"
     cmds:
       - git submodule update --init

--- a/src/go.mod
+++ b/src/go.mod
@@ -93,6 +93,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
-
-//Only used for local development!
-//replace github.com/opslevel/opslevel-go/v2023 => ./submodules/opslevel-go


### PR DESCRIPTION
Add `workspace` task to Taskfile to make `cli` <--> `opslevel-go` development setup easier(?) and more apparent.
Add `testcov` task to Taskfile for simpler CI and for easier parity for local testing.

I added `go.work*` to `.gitignore` since `go.work` only works if the `opslevel-go` submodule has been pulled in. This is handled by `task workspace` in CI testing and locally - and can be safely ignored in all other situations.