### PR TITLE
Add support for Webhook Actions and Trigger Definitions

### DIFF
--- a/.changes/unreleased/Feature-20230811-151612.yaml
+++ b/.changes/unreleased/Feature-20230811-151612.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for handling Webhook Actions
+time: 2023-08-11T15:16:12.064594-04:00

--- a/.changes/unreleased/Feature-20230811-151626.yaml
+++ b/.changes/unreleased/Feature-20230811-151626.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for handling Trigger Definitions
+time: 2023-08-11T15:16:26.372008-04:00

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -66,9 +66,9 @@ var listActionCmd = &cobra.Command{
 		if isJsonOutput() {
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
 		} else {
-			w := common.NewTabWriter("ID", "NAME")
+			w := common.NewTabWriter("ID", "NAME", "HTTP_METHOD", "WEBHOOK_URL")
 			for _, item := range list {
-				fmt.Fprintf(w, "%s\t%s\t\n", item.Id, item.Name)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", item.Id, item.Name, item.HTTPMethod, item.WebhookURL)
 			}
 			w.Flush()
 		}

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/creasty/defaults"
+	"github.com/opslevel/opslevel-go/v2023"
+
+	"github.com/opslevel/cli/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// TODO: examples for create, update
+
+var actionType string
+
+var createActionCmd = &cobra.Command{
+	Use:   "action --type=$ACTION_TYPE",
+	Short: "Create an action",
+	Long:  "Create an action",
+	Example: `
+cat << EOF | opslevel create action --type=webhook -f -
+...
+EOF`,
+	Run: func(cmd *cobra.Command, args []string) {
+		switch actionType {
+		case "webhook":
+			input, err := readWebhookActionInput()
+			cobra.CheckErr(err)
+			result, err := getClientGQL().CreateWebhookAction(*input)
+			cobra.CheckErr(err)
+			fmt.Printf("created webhook action: %s\n", result.Id)
+		default:
+			err := errors.New("unknown action type: " + args[0])
+			cobra.CheckErr(err)
+		}
+	},
+}
+
+var getActionCmd = &cobra.Command{
+	Use:        "action ID",
+	Short:      "Get details about an action",
+	Long:       "Get details about an action",
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		key := args[0]
+		action, err := getClientGQL().GetCustomAction(*opslevel.NewIdentifier(key))
+		cobra.CheckErr(err)
+		common.PrettyPrint(action)
+	},
+}
+
+var listActionCmd = &cobra.Command{
+	Use:     "action",
+	Aliases: []string{"actions"},
+	Short:   "List actions",
+	Long:    "List actions",
+	Run: func(cmd *cobra.Command, args []string) {
+		resp, err := getClientGQL().ListCustomActions(nil)
+		cobra.CheckErr(err)
+		list := resp.Nodes
+		if isJsonOutput() {
+			common.JsonPrint(json.MarshalIndent(list, "", "    "))
+		} else {
+			w := common.NewTabWriter("ID", "NAME")
+			for _, item := range list {
+				fmt.Fprintf(w, "%s\t%s\t\n", item.Id, item.Name)
+			}
+			w.Flush()
+		}
+	},
+}
+
+var updateActionCmd = &cobra.Command{
+	Use:   "action ID",
+	Short: "Update an action",
+	Long:  "Update an action",
+	Example: `
+cat << EOF | opslevel update action --type=webhook $ACTION_ID -f -
+...
+EOF`,
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		key := args[0]
+		switch actionType {
+		case "webhook":
+			input, err := readWebhookActionInput()
+			cobra.CheckErr(err)
+			updateInput := &opslevel.CustomActionsWebhookActionUpdateInput{
+				Id:             *opslevel.NewID(key),
+				Name:           &input.Name,
+				Description:    input.Description,
+				LiquidTemplate: &input.LiquidTemplate,
+				WebhookURL:     &input.WebhookURL,
+				HTTPMethod:     input.HTTPMethod,
+				Headers:        &input.Headers,
+			}
+			action, err := getClientGQL().UpdateWebhookAction(*updateInput)
+			cobra.CheckErr(err)
+			common.JsonPrint(json.MarshalIndent(action, "", "    "))
+		default:
+			err := errors.New("unknown action type: " + actionType)
+			cobra.CheckErr(err)
+		}
+	},
+}
+
+var deleteActionCmd = &cobra.Command{
+	Use:        "action ID",
+	Short:      "Delete an action",
+	Long:       "Delete an action",
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		key := args[0]
+		err := getClientGQL().DeleteWebhookAction(*opslevel.NewIdentifier(key))
+		cobra.CheckErr(err)
+		fmt.Printf("created webhook action: %s\n", key)
+	},
+}
+
+func init() {
+	createCmd.AddCommand(createActionCmd)
+	createCmd.Flags().StringVar(&actionType, "type", "webhook", "action type, default=webhook")
+	updateCmd.AddCommand(updateActionCmd)
+	updateCmd.Flags().StringVar(&actionType, "type", "webhook", "action type, default=webhook")
+	getCmd.AddCommand(getActionCmd)
+	listCmd.AddCommand(listActionCmd)
+	deleteCmd.AddCommand(deleteActionCmd)
+}
+
+func readWebhookActionInput() (*opslevel.CustomActionsWebhookActionCreateInput, error) {
+	readInputConfig()
+	evt := &opslevel.CustomActionsWebhookActionCreateInput{}
+	viper.Unmarshal(&evt)
+	if err := defaults.Set(evt); err != nil {
+		return nil, err
+	}
+	return evt, nil
+}

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -13,8 +13,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// TODO: examples for create, update
-
 var actionType string
 
 var createActionCmd = &cobra.Command{
@@ -23,7 +21,29 @@ var createActionCmd = &cobra.Command{
 	Long:  "Create an action",
 	Example: `
 cat << EOF | opslevel create action --type=webhook -f -
-...
+name: "Page The On Call"
+description: "Pages the On Call"
+webhookUrl: "https://api.pagerduty.com/incidents"
+httpMethod: "POST"
+headers:
+  accept: "application/vnd.pagerduty+json;version=2"
+  authorization: "Token token=XXXXXXXXXXXXX"
+  from: "someone@example.com"
+payload: |
+  {
+      "incident": {
+          "type": "incident",
+          "title": "{{manualInputs.IncidentTitle}}",
+          "service": {
+            "id": "{{ service | tag_value: 'pd_id' }}",
+            "type": "service_reference"
+          },
+          "body": {
+            "type": "incident_body",
+            "details": "Incident triggered from OpsLevel by {{user.name}} with the email {{user.email}}. {{manualInputs.IncidentDescription}}"
+          }
+      }
+  }
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
 		switch actionType {
@@ -81,7 +101,11 @@ var updateActionCmd = &cobra.Command{
 	Long:  "Update an action",
 	Example: `
 cat << EOF | opslevel update action --type=webhook $ACTION_ID -f -
-...
+description: "Pages the oncall and creates an incident"
+headers:
+  accept: "application/vnd.pagerduty+json;version=2"
+  authorization: "Token token=XXXXXXXXXXXXX"
+  from: "someone-else@example.com"
 EOF`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID"},

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -120,15 +120,15 @@ var deleteActionCmd = &cobra.Command{
 		key := args[0]
 		err := getClientGQL().DeleteWebhookAction(*opslevel.NewIdentifier(key))
 		cobra.CheckErr(err)
-		fmt.Printf("created webhook action: %s\n", key)
+		fmt.Printf("deleted webhook action: %s\n", key)
 	},
 }
 
 func init() {
 	createCmd.AddCommand(createActionCmd)
-	createCmd.Flags().StringVar(&actionType, "type", "webhook", "action type, default=webhook")
+	createActionCmd.Flags().StringVar(&actionType, "type", "webhook", "action type, default=webhook")
 	updateCmd.AddCommand(updateActionCmd)
-	updateCmd.Flags().StringVar(&actionType, "type", "webhook", "action type, default=webhook")
+	updateActionCmd.Flags().StringVar(&actionType, "type", "webhook", "action type, default=webhook")
 	getCmd.AddCommand(getActionCmd)
 	listCmd.AddCommand(listActionCmd)
 	deleteCmd.AddCommand(deleteActionCmd)

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -28,7 +28,7 @@ EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
 		switch actionType {
 		case "webhook":
-			input, err := readWebhookActionInput()
+			input, err := readWebhookActionCreateInput()
 			cobra.CheckErr(err)
 			result, err := getClientGQL().CreateWebhookAction(*input)
 			cobra.CheckErr(err)
@@ -89,18 +89,10 @@ EOF`,
 		key := args[0]
 		switch actionType {
 		case "webhook":
-			input, err := readWebhookActionInput()
+			input, err := readWebhookActionUpdateInput()
+			input.Id = *opslevel.NewID(key)
 			cobra.CheckErr(err)
-			updateInput := &opslevel.CustomActionsWebhookActionUpdateInput{
-				Id:             *opslevel.NewID(key),
-				Name:           &input.Name,
-				Description:    input.Description,
-				LiquidTemplate: &input.LiquidTemplate,
-				WebhookURL:     &input.WebhookURL,
-				HTTPMethod:     input.HTTPMethod,
-				Headers:        &input.Headers,
-			}
-			action, err := getClientGQL().UpdateWebhookAction(*updateInput)
+			action, err := getClientGQL().UpdateWebhookAction(*input)
 			cobra.CheckErr(err)
 			common.JsonPrint(json.MarshalIndent(action, "", "    "))
 		default:
@@ -134,9 +126,19 @@ func init() {
 	deleteCmd.AddCommand(deleteActionCmd)
 }
 
-func readWebhookActionInput() (*opslevel.CustomActionsWebhookActionCreateInput, error) {
+func readWebhookActionCreateInput() (*opslevel.CustomActionsWebhookActionCreateInput, error) {
 	readInputConfig()
 	evt := &opslevel.CustomActionsWebhookActionCreateInput{}
+	viper.Unmarshal(&evt)
+	if err := defaults.Set(evt); err != nil {
+		return nil, err
+	}
+	return evt, nil
+}
+
+func readWebhookActionUpdateInput() (*opslevel.CustomActionsWebhookActionUpdateInput, error) {
+	readInputConfig()
+	evt := &opslevel.CustomActionsWebhookActionUpdateInput{}
 	viper.Unmarshal(&evt)
 	if err := defaults.Set(evt); err != nil {
 		return nil, err

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -61,11 +61,11 @@ EOF`,
 }
 
 var getActionCmd = &cobra.Command{
-	Use:        "action ID",
+	Use:        "action ID|ALIAS",
 	Short:      "Get details about an action",
 	Long:       "Get details about an action",
 	Args:       cobra.ExactArgs(1),
-	ArgAliases: []string{"ID"},
+	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
 		action, err := getClientGQL().GetCustomAction(*opslevel.NewIdentifier(key))
@@ -127,11 +127,11 @@ EOF`,
 }
 
 var deleteActionCmd = &cobra.Command{
-	Use:        "action ID",
+	Use:        "action ID|ALIAS",
 	Short:      "Delete an action",
 	Long:       "Delete an action",
 	Args:       cobra.ExactArgs(1),
-	ArgAliases: []string{"ID"},
+	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
 		err := getClientGQL().DeleteWebhookAction(*opslevel.NewIdentifier(key))

--- a/src/cmd/trigger_definition.go
+++ b/src/cmd/trigger_definition.go
@@ -55,11 +55,11 @@ EOF`,
 }
 
 var getTriggerDefinitionCmd = &cobra.Command{
-	Use:        "trigger-definition ID",
+	Use:        "trigger-definition ID|ALIAS",
 	Short:      "Get details about a trigger definition",
 	Long:       "Get details about a trigger definition",
 	Args:       cobra.ExactArgs(1),
-	ArgAliases: []string{"ID"},
+	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
 		triggerDefinition, err := getClientGQL().GetTriggerDefinition(*opslevel.NewIdentifier(key))
@@ -112,11 +112,11 @@ EOF`,
 }
 
 var deleteTriggerDefinitionCmd = &cobra.Command{
-	Use:        "trigger-definition ID",
+	Use:        "trigger-definition ID|ALIAS",
 	Short:      "Delete a trigger definition",
 	Long:       "Delete a trigger definition",
 	Args:       cobra.ExactArgs(1),
-	ArgAliases: []string{"ID"},
+	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
 		err := getClientGQL().DeleteTriggerDefinition(*opslevel.NewIdentifier(key))

--- a/src/cmd/trigger_definition.go
+++ b/src/cmd/trigger_definition.go
@@ -12,15 +12,38 @@ import (
 	"github.com/spf13/viper"
 )
 
-// TODO: examples for create, update
-
 var createTriggerDefinitionCmd = &cobra.Command{
 	Use:   "trigger-definition",
 	Short: "Create a trigger definition",
 	Long:  "Create a trigger definition",
 	Example: `
 cat << EOF | opslevel create trigger-definition -f -
-...
+name: "Page The On Call"
+description: "Pages the On Call"
+owner: "some_team"
+action: "some_action"
+accessControl: "everyone"
+manualInputsDefinition: |
+  version: 1
+  inputs:
+    - identifier: IncidentTitle
+      displayName: Title
+      description: Title of the incident to trigger
+      type: text_input
+      required: true
+      maxLength: 60
+      defaultValue: Service Incident Manual Trigger
+    - identifier: IncidentDescription
+      displayName: Incident Description
+      description: The description of the incident
+      type: text_area
+      required: true
+responseTemplate: |
+  {% if response.status >= 200 and response.status < 300 %}
+  success
+  {% else %}
+  failure
+  {% endif %}
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
 		input, err := readTriggerDefinitionCreateInput()
@@ -72,7 +95,8 @@ var updateTriggerDefinitionCmd = &cobra.Command{
 	Long:  "Update a trigger definition",
 	Example: `
 cat << EOF | opslevel update trigger-definition $TRIGGER_ID -f -
-...
+description: "Pages the On Call via PagerDuty"
+accessControl: "service_owners"
 EOF`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID"},

--- a/src/cmd/trigger_definition.go
+++ b/src/cmd/trigger_definition.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/creasty/defaults"
+	"github.com/opslevel/opslevel-go/v2023"
+
+	"github.com/opslevel/cli/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// TODO: examples for create, update
+
+var createTriggerDefinitionCmd = &cobra.Command{
+	Use:   "trigger-definition",
+	Short: "Create a trigger definition",
+	Long:  "Create a trigger definition",
+	Example: `
+cat << EOF | opslevel create trigger-definition -f -
+...
+EOF`,
+	Run: func(cmd *cobra.Command, args []string) {
+		input, err := readTriggerDefinitionInput()
+		cobra.CheckErr(err)
+		result, err := getClientGQL().CreateTriggerDefinition(*input)
+		cobra.CheckErr(err)
+		fmt.Printf("created trigger definition: %s\n", result.Id)
+	},
+}
+
+var getTriggerDefinitionCmd = &cobra.Command{
+	Use:        "trigger-definition ID",
+	Short:      "Get details about a trigger definition",
+	Long:       "Get details about a trigger definition",
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		key := args[0]
+		triggerDefinition, err := getClientGQL().GetTriggerDefinition(*opslevel.NewIdentifier(key))
+		cobra.CheckErr(err)
+		common.PrettyPrint(triggerDefinition)
+	},
+}
+
+var listTriggerDefinitionCmd = &cobra.Command{
+	Use:     "trigger-definition",
+	Aliases: []string{"trigger-definitions"},
+	Short:   "List trigger definitions",
+	Long:    "List trigger definitions",
+	Run: func(cmd *cobra.Command, args []string) {
+		resp, err := getClientGQL().ListTriggerDefinitions(nil)
+		cobra.CheckErr(err)
+		list := resp.Nodes
+		if isJsonOutput() {
+			common.JsonPrint(json.MarshalIndent(list, "", "    "))
+		} else {
+			w := common.NewTabWriter("ID", "NAME")
+			for _, item := range list {
+				fmt.Fprintf(w, "%s\t%s\t\n", item.Id, item.Name)
+			}
+			w.Flush()
+		}
+	},
+}
+
+var updateTriggerDefinitionCmd = &cobra.Command{
+	Use:   "trigger-definition ID",
+	Short: "Update a trigger definition",
+	Long:  "Update a trigger definition",
+	Example: `
+cat << EOF | opslevel update trigger-definition $TRIGGER_ID -f -
+...
+EOF`,
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		key := args[0]
+		input, err := readTriggerDefinitionInput()
+		cobra.CheckErr(err)
+		updateInput := &opslevel.CustomActionsTriggerDefinitionUpdateInput{
+			Id:                     *opslevel.NewID(key),
+			Name:                   &input.Name,
+			Description:            input.Description,
+			Owner:                  &input.Owner,
+			Action:                 &input.Action,
+			Filter:                 input.Filter,
+			ManualInputsDefinition: &input.ManualInputsDefinition,
+			Published:              input.Published,
+			AccessControl:          input.AccessControl,
+			ResponseTemplate:       &input.ResponseTemplate,
+			EntityType:             input.EntityType,
+		}
+		triggerDefinition, err := getClientGQL().UpdateTriggerDefinition(*updateInput)
+		cobra.CheckErr(err)
+		common.JsonPrint(json.MarshalIndent(triggerDefinition, "", "    "))
+	},
+}
+
+var deleteTriggerDefinitionCmd = &cobra.Command{
+	Use:        "trigger-definition ID",
+	Short:      "Delete a trigger definition",
+	Long:       "Delete a trigger definition",
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		key := args[0]
+		err := getClientGQL().DeleteTriggerDefinition(*opslevel.NewIdentifier(key))
+		cobra.CheckErr(err)
+		fmt.Printf("created trigger definition: %s\n", key)
+	},
+}
+
+func init() {
+	createCmd.AddCommand(createTriggerDefinitionCmd)
+	updateCmd.AddCommand(updateTriggerDefinitionCmd)
+	getCmd.AddCommand(getTriggerDefinitionCmd)
+	listCmd.AddCommand(listTriggerDefinitionCmd)
+	deleteCmd.AddCommand(deleteTriggerDefinitionCmd)
+}
+
+func readTriggerDefinitionInput() (*opslevel.CustomActionsTriggerDefinitionCreateInput, error) {
+	readInputConfig()
+	evt := &opslevel.CustomActionsTriggerDefinitionCreateInput{}
+	viper.Unmarshal(&evt)
+	if err := defaults.Set(evt); err != nil {
+		return nil, err
+	}
+	return evt, nil
+}

--- a/src/cmd/trigger_definition.go
+++ b/src/cmd/trigger_definition.go
@@ -109,7 +109,7 @@ var deleteTriggerDefinitionCmd = &cobra.Command{
 		key := args[0]
 		err := getClientGQL().DeleteTriggerDefinition(*opslevel.NewIdentifier(key))
 		cobra.CheckErr(err)
-		fmt.Printf("created trigger definition: %s\n", key)
+		fmt.Printf("deleted trigger definition: %s\n", key)
 	},
 }
 


### PR DESCRIPTION
## Summary

Allow CLI users to create webhook actions and trigger definitions!

## Tophatting

### Actions

```
$ go run main.go create action -f action_create.yaml
created webhook action: Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi8yMjY
```

```
$ go run main.go update action Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi8yMjY -f action_update.yaml
{
    "Aliases": [],
    "Id": "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi8yMjY",
    "Description": "Pages the oncall and creates an incident",
    "LiquidTemplate": "",
    "Name": "Page The On Call",
    "Headers": "{\"accept\":\"application/vnd.pagerduty+json;version=2\",\"authorization\":\"Token token=XXXXXXXXXXXXX\",\"from\":\"someone-else@example.com\"}",
    "HTTPMethod": "POST",
    "WebhookURL": "https://api.pagerduty.com/incidents"
}                                                                                                                                                                                  
```

### Trigger definitions

```
$ go run main.go create trigger-definition -f trigger_create.yaml
created trigger definition: Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjAx
```

```
$ go run main.go update trigger-definition Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjAx -f trigger_update.yaml
{
    "Action": {
        "Aliases": [],
        "Id": "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi85Mw"
    },
    "Aliases": [],
    "Description": "Pages the On Call via PagerDuty",
    "Filter": {
        "Id": null,
        "Name": ""
    },
    "Id": "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjAx",
    "ManualInputsDefinition": "version: 1\ninputs:\n  - identifier: IncidentTitle\n    displayName: Title\n    description: Title of the incident to trigger\n    type: text_input\n    required: true\n    maxLength: 60\n    defaultValue: Service Incident Manual Trigger\n  - identifier: IncidentDescription\n    displayName: Incident Description\n    description: The description of the incident\n    type: text_area\n    required: true\n",
    "Name": "Page The On Call",
    "Owner": {
        "Alias": "platform",
        "Id": "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNjc4"
    },
    "Published": false,
    "Timestamps": {
        "createdAt": "2023-08-11T19:06:20.750274Z",
        "updatedAt": "2023-08-11T19:08:03.356306Z"
    },
    "AccessControl": "service_owners",
    "ResponseTemplate": "{% if response.status \u003e= 200 and response.status \u003c 300 %}\n## Congratulations!\nYour request for {{ service.name }} has succeeded. See the incident here: {{response.body.incident.html_url}}\n{% else %}\n## Oops something went wrong!\nPlease contact [{{ action_owner.name }}]({{ action_owner.href }}) for more help.\n{% endif %}",
    "EntityType": "SERVICE"
}
```