### PR TITLE
make `get tags` alway require a `key`, add `list tags` command to fetch all keys

### DIFF
--- a/.changes/unreleased/Bugfix-20230922-140819.yaml
+++ b/.changes/unreleased/Bugfix-20230922-140819.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: BREAKING CHANGE - fix get/list tags on an object returning a nonzero exit code
+  if no tag matches, return empty JSON array instead
+time: 2023-09-22T14:08:19.025844-04:00

--- a/.changes/unreleased/Feature-20230922-140908.yaml
+++ b/.changes/unreleased/Feature-20230922-140908.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: BREAKING CHANGE - split up `get tag KEY` and `list tags`. `get tag KEY` gets
+  all tags matching `KEY`. `list tags` lists all tags on an object
+time: 2023-09-22T14:09:08.031392-04:00

--- a/src/cmd/tag.go
+++ b/src/cmd/tag.go
@@ -135,17 +135,13 @@ opslevel get tag --type=Service ID|ALIAS KEY | jq
 		tags, err := GetTags(result)
 		cobra.CheckErr(err)
 
-		var output []opslevel.Tag
+		output := []opslevel.Tag{}
 		for _, tag := range tags.Nodes {
 			if tagKey == tag.Key {
 				output = append(output, tag)
 			}
 		}
 
-		// return empty JSON array instead of null
-		if len(output) == 0 {
-			output = make([]opslevel.Tag, 0)
-		}
 		common.PrettyPrint(output)
 	},
 }


### PR DESCRIPTION
## Changelog

- [x] The `get tag KEY` command will no longer exit with a non-zero exit code when there are no tags that match `KEY`. Instead, it will just output an empty JSON array `[]`. This behaviour is more predictable - there being no matching tags is not a CLI/API error after all.
- [x] The `get tag` command now requires an argument, `KEY`. If the user wants to list all tags on an object, they have to use `list tags`
- [x] The `list tags` command is added and works the same as `get tag KEY`, except it just returns all tags without filtering for anything. 

## Tophatting

### `get tag KEY`

Can find tags where `key == KEY`.

```
$ opslevel get tag --type team $PLATFORM newkey
[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwMTgwNTc3",
    "key": "newkey",
    "value": "newvalue"
  },
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwMTgwNTgx",
    "key": "newkey",
    "value": "secondvalue"
  }
]
```

Will not error out if no keys match `KEY`, will instead output empty JSON array.

```
$ opslevel get tag --type team $PLATFORM nonexistantkey
[]

```

### `list tags`

Should be able to output all tags.

```
$ opslevel list tags --type team $PLATFORM
[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwMTgwNTc3",
    "key": "newkey",
    "value": "newvalue"
  },
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwMTgwNTgx",
    "key": "newkey",
    "value": "secondvalue"
  },
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwMTgwNzMw",
    "key": "secondkey",
    "value": "rofl"
  }
]

```

If no tags exist, should output empty array.

```
~/repos/cli/src list-tags ❯ opslevel list tags --type team $PLATFORM                                                 Ruby 3.0.0 02:04:26 pm
[]

```