### PR TITLE
TaggableResourceInterface, support User + InfrastructureResource tags

### DIFF
--- a/.changes/unreleased/Bugfix-20230925-161552.yaml
+++ b/.changes/unreleased/Bugfix-20230925-161552.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Can create and get/read tags on domains, systems, infra, users
+time: 2023-09-25T16:15:52.046136-04:00

--- a/src/cmd/tag.go
+++ b/src/cmd/tag.go
@@ -13,50 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TODO: combine TaggableResourceFetchFunction and TaggableResourceFetchAliasFunction once the ObjectGet functions have been
-// harmonized to support both get by ID and get by Alias
-type TaggableResourceFetchFunction func(id opslevel.ID) (opslevel.TaggableResourceInterface, error)
-
-var TaggableResourceFetchFunctions = map[opslevel.TaggableResource]TaggableResourceFetchFunction{
-	opslevel.TaggableResourceService: func(id opslevel.ID) (opslevel.TaggableResourceInterface, error) { return getClientGQL().GetService(id) },
-	opslevel.TaggableResourceRepository: func(id opslevel.ID) (opslevel.TaggableResourceInterface, error) {
-		return getClientGQL().GetRepository(id)
-	},
-	opslevel.TaggableResourceTeam: func(id opslevel.ID) (opslevel.TaggableResourceInterface, error) { return getClientGQL().GetTeam(id) },
-	// opslevel.TaggableResourceUser: func(id opslevel.ID) (opslevel.TaggableResourceInterface, error) {
-	// 	return getClientGQL().GetUser(string(id))
-	// },
-	opslevel.TaggableResourceDomain: func(id opslevel.ID) (opslevel.TaggableResourceInterface, error) {
-		return getClientGQL().GetDomain(string(id))
-	},
-	opslevel.TaggableResourceSystem: func(id opslevel.ID) (opslevel.TaggableResourceInterface, error) {
-		return getClientGQL().GetSystem(string(id))
-	},
-	// opslevel.TaggableResourceInfrastructureresource: func(id opslevel.ID) (opslevel.TaggableResourceInterface, error) {
-	// 	return getClientGQL().GetInfrastructure(string(id))
-	// },
-}
-
-type TaggableResourceFetchAliasFunction func(alias string) (opslevel.TaggableResourceInterface, error)
-
-var TaggableResourceFetchAliasFunctions = map[opslevel.TaggableResource]TaggableResourceFetchAliasFunction{
-	opslevel.TaggableResourceService: func(alias string) (opslevel.TaggableResourceInterface, error) {
-		return getClientGQL().GetServiceWithAlias(alias)
-	},
-	opslevel.TaggableResourceRepository: func(alias string) (opslevel.TaggableResourceInterface, error) {
-		return getClientGQL().GetRepositoryWithAlias(alias)
-	},
-	opslevel.TaggableResourceTeam: func(alias string) (opslevel.TaggableResourceInterface, error) {
-		return getClientGQL().GetTeamWithAlias(alias)
-	},
-	// opslevel.TaggableResourceUser:   func(alias string) (opslevel.TaggableResourceInterface, error) { return getClientGQL().GetUser(alias) },
-	opslevel.TaggableResourceDomain: func(alias string) (opslevel.TaggableResourceInterface, error) { return getClientGQL().GetDomain(alias) },
-	opslevel.TaggableResourceSystem: func(alias string) (opslevel.TaggableResourceInterface, error) { return getClientGQL().GetSystem(alias) },
-	// opslevel.TaggableResourceInfrastructureresource: func(alias string) (opslevel.TaggableResourceInterface, error) {
-	// 	return getClientGQL().GetInfrastructure(alias)
-	// },
-}
-
 var resourceType string
 
 var createTagCmd = &cobra.Command{
@@ -128,16 +84,9 @@ opslevel get tag --type=Service ID|ALIAS KEY | jq
 		resource := args[0]
 		tagKey := args[1]
 
-		var result opslevel.TaggableResourceInterface
-		if opslevel.IsID(resource) {
-			id := opslevel.ID(resource)
-			result, err = TaggableResourceFetchFunctions[opslevel.TaggableResource(resourceType)](id)
-		} else {
-			alias := args[0]
-			result, err = TaggableResourceFetchAliasFunctions[opslevel.TaggableResource(resourceType)](alias)
-		}
-
-		tags, err := result.GetTags(_clientGQL, nil)
+		result, err := getClientGQL().GetTaggableResource(resourceType, resource)
+		cobra.CheckErr(err)
+		tags, err := result.GetTags(getClientGQL(), nil)
 		cobra.CheckErr(err)
 
 		output := []opslevel.Tag{}
@@ -167,16 +116,9 @@ opslevel list tag --type=Service ID|ALIAS
 
 		resource := args[0]
 
-		var result opslevel.TaggableResourceInterface
-		if opslevel.IsID(resource) {
-			id := opslevel.ID(resource)
-			result, err = TaggableResourceFetchFunctions[opslevel.TaggableResource(resourceType)](id)
-		} else {
-			alias := args[0]
-			result, err = TaggableResourceFetchAliasFunctions[opslevel.TaggableResource(resourceType)](alias)
-		}
-
-		tags, err := result.GetTags(_clientGQL, nil)
+		result, err := getClientGQL().GetTaggableResource(resourceType, resource)
+		cobra.CheckErr(err)
+		tags, err := result.GetTags(getClientGQL(), nil)
 		cobra.CheckErr(err)
 
 		common.PrettyPrint(tags.Nodes)


### PR DESCRIPTION
## Issue

https://github.com/OpsLevel/team-platform/issues/104

Relies on https://github.com/OpsLevel/opslevel-go/pull/255

## Changelog

- [x] Adapt code for `TaggableResourceInterface` and new lookup functions
- [ ] Add support for InfrastructureResource
- [ ] Add support for User

## Tophatting

### List

```
~/repos/cli/src tag-the-planet !2 ❯ opslevel list tags --type system $SYSTEM                                      3s Ruby 3.0.0 03:14:25 pm
[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwNDI2MDMx",
    "key": "hello",
    "value": "world"
  },
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwNTUxNDc4",
    "key": "sys-cheesy",
    "value": "attack"
  }
]

```

### Get

```
~/repos/cli/src tag-the-planet !2 ❯ opslevel get tag --type system $SYSTEM hello                               х INT Ruby 3.0.0 03:15:03 pm
[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwNDI2MDMx",
    "key": "hello",
    "value": "world"
  }
]

~/repos/cli/src tag-the-planet wip ❯ opslevel get tag --type system $SYSTEM nonexistent                           3s Ruby 3.0.0 03:16:10 pm
[]
```