### PR TITLE
allow "infra" when managing infra tags

### DIFF
--- a/.changes/unreleased/Feature-20231004-142513.yaml
+++ b/.changes/unreleased/Feature-20231004-142513.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add 'infra' to type flag for tag management
+time: 2023-10-04T14:25:13.846714-05:00

--- a/src/cmd/tag.go
+++ b/src/cmd/tag.go
@@ -201,6 +201,10 @@ func validateResourceTypeArg() error {
 
 	// if lowercase, check if it exists. if not, error out
 	lowercaseInput := strings.ToLower(resourceType)
+	if lowercaseInput == "infra" {
+		resourceType = string(opslevel.TaggableResourceInfrastructureresource)
+		return nil
+	}
 	lowercaseMap := make(map[string]string)
 	for _, s := range opslevel.AllTaggableResource {
 		lowercaseMap[strings.ToLower(s)] = s


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add `infra` as a type when managing tags. Otherwise users would have to type out `--type=InfrastructureResource`
```
opslevel list tag --type=infra <infra-ID>
```

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```
opslevel get tag --type=infra Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzU1OTczOA neat-key-2
[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjYyNDUw",
    "key": "neat-key-2",
    "value": "neat-value-2"
  }
]

opslevel list tag --type=infra Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzU1OTczOA
[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjYyNDUw",
    "key": "neat-key-2",
    "value": "neat-value-2"
  }
]
```
