### PR TITLE
deprecate ownerAlias

### DIFF
--- a/.changes/unreleased/Refactor-20231020-134153.yaml
+++ b/.changes/unreleased/Refactor-20231020-134153.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: BREAKING CHANGE ownerAlias deprecated on service inputs
+time: 2023-10-20T13:41:53.279163-04:00

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -216,7 +216,7 @@ EOF
 			owner := reader.Text("Owner")
 			if tier != "" {
 				if item, ok := opslevel.Cache.Teams[owner]; ok {
-					input.Owner = *opslevel.NewIdentifier(item.Alias)
+					input.Owner = opslevel.NewIdentifier(item.Alias)
 				}
 			}
 			service, err := getClientGQL().CreateService(input)

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -208,13 +208,13 @@ EOF
 				}
 			}
 			lifecycle := reader.Text("Lifecycle")
-			if tier != "" {
+			if lifecycle != "" {
 				if item, ok := opslevel.Cache.Lifecycles[lifecycle]; ok {
 					input.Lifecycle = item.Alias
 				}
 			}
 			owner := reader.Text("Owner")
-			if tier != "" {
+			if owner != "" {
 				if item, ok := opslevel.Cache.Teams[owner]; ok {
 					input.Owner = opslevel.NewIdentifier(item.Alias)
 				}

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -30,7 +30,8 @@ product: "OSS"
 language: "Go"
 tier: "tier_4"
 framework: "fasthttp"
-owner: "Platform"
+owner:
+  alias: "Platform"
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
 		input, err := readServiceCreateInput()
@@ -215,7 +216,7 @@ EOF
 			owner := reader.Text("Owner")
 			if tier != "" {
 				if item, ok := opslevel.Cache.Teams[owner]; ok {
-					input.Owner = item.Alias
+					input.Owner = *opslevel.NewIdentifier(item.Alias)
 				}
 			}
 			service, err := getClientGQL().CreateService(input)

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -227,7 +227,7 @@ func flattenTier(value opslevel.Tier) string {
 
 func flattenOwner(value opslevel.TeamId) string {
 	if value.Id != "" {
-		return fmt.Sprintf("owner_alias = opslevel_team.%s.alias", value.Alias)
+		return fmt.Sprintf("owner = opslevel_team.%s.alias", value.Alias)
 	}
 	return ""
 }


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/opslevel-go/issues/276

## Changelog

- [x] Update help for using owner as an identifier input
- [x] Make a `changie` entry

## Tophatting

```
$ cat service.yml
name: "some new service from CLI"
description: "some new service created on CLI"
product: "whatever"
language: "ruby"
tier: "tier_2"
framework: "rails"
owner:
  alias: "platform"%
$ opslevel create service -f service.yml
"Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84MjA1OQ"

$ cat service_update.yml
id: "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84MjA1OQ"
description: "some new service created on CLI - now updated"
owner:
  id: "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTEwOA"%
$ opslevel update service -f service_update.yml
# success, truncating JSON output.
```