### PR TITLE
update scorecard example docs to include affectsOverallServiceLevels

### DIFF
--- a/src/cmd/scorecard.go
+++ b/src/cmd/scorecard.go
@@ -21,6 +21,7 @@ cat << EOF | opslevel create scorecard -f -
 name: "new scorecard"
 description: "a newly created scorecard"
 ownerId: "XXX_team_id_XXX"
+affectsOverallServiceLevels: false
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
 		input, err := readScorecardInput()
@@ -78,6 +79,7 @@ cat << EOF | opslevel update scorecard $ID -f -
 name: "updated scorecard"
 description: "an updated scorecard"
 ownerId: "XXX_team_id_XXX"
+affectsOverallServiceLevels: true
 EOF`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},


### PR DESCRIPTION
## Issues

[#71](https://github.com/OpsLevel/team-platform/issues/71)

## Changelog

Update scorecard example docs to include `AffectsOverallServiceLevels` for scorecard create and update.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A only updated command docs

## Tophatting

`opslevel create scorecard -f sc.yaml` where `sc.yaml` looks very close to example in command docs.
Update `sc.yaml` to switch `affectsOverallServiceLevels: false` to `affectsOverallServiceLevels: true`
`opslevel update scorecard <scorecard-ID> -f sc.yaml`
