### PR TITLE
add Parent Teams to add, create, import of teams

### DIFF
--- a/.changes/unreleased/Feature-20231030-150050.yaml
+++ b/.changes/unreleased/Feature-20231030-150050.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add "parentTeam" field to "import teams" command and team command examples
+time: 2023-10-30T15:00:50.727989-05:00

--- a/.changes/unreleased/Removed-20231030-150005.yaml
+++ b/.changes/unreleased/Removed-20231030-150005.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: remove "group" field from "import teams" command
+time: 2023-10-30T15:00:05.134799-05:00

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -20,9 +20,9 @@ var createTeamCmd = &cobra.Command{
 	Example: `opslevel create team my-team
 
 cat << EOF | opslevel create team my-team" -f -
-managerEmail: "manager@example.com""
-group:
-  alias: "my-group"
+managerEmail: "manager@example.com"
+parentTeam:
+  alias: "parent-team"
 responsibilities: "all the things"
 EOF`,
 	Args:       cobra.ExactArgs(1),
@@ -120,8 +120,8 @@ var updateTeamCmd = &cobra.Command{
 	Example: `
 cat << EOF | opslevel update team my-team" -f -
 managerEmail: "manager@example.com""
-group:
-  alias: "my-group"
+parentTeam:
+  alias: "parent-team-2"
 responsibilities: "all the things"
 EOF
 `,
@@ -271,10 +271,10 @@ var importTeamsCmd = &cobra.Command{
 	Aliases: []string{"teams"},
 	Short:   "Imports teams from a CSV",
 	Long: `Imports a list of teams from a CSV file with the column headers:
-Name,Manager,Responsibilities,Group`,
+Name,Manager,Responsibilities,ParentTeam`,
 	Example: `
 cat << EOF | opslevel import teams -f -
-Name,Manager,Responsibilities,Group
+Name,Manager,Responsibilities,ParentTeam
 Platform,kyle@opslevel.com,Makes Tools,engineering
 Sales,john@opslevel.com,Sells Tools,product
 EOF
@@ -289,9 +289,9 @@ EOF
 				ManagerEmail:     reader.Text("Manager"),
 				Responsibilities: reader.Text("Responsibilities"),
 			}
-			group := reader.Text("Group")
-			if group != "" {
-				input.Group = opslevel.NewIdentifier(group)
+			parentTeam := reader.Text("ParentTeam")
+			if parentTeam != "" {
+				input.ParentTeam = opslevel.NewIdentifier(parentTeam)
 			}
 			team, err := getClientGQL().CreateTeam(input)
 			if err != nil {


### PR DESCRIPTION
## Issues

[#130](https://github.com/OpsLevel/team-platform/issues/130)

## Changelog

Update example docs for `team create` and `team update` commands.
Update `opslevel.TeamCreateInput` to update `ParentTeam` field instead of deprecated `Group` field

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

1. Create a `my-team.csv` file:
```csv
Name,Manager,Responsibilities,ParentTeam
Team Fresh Water,samuel@example.com,Makes Tools,go_team
Team Salt Water,saul@example.com,Dev Work,QA
```

2. Run `opslevel import teams -f my-team.csv`

3. Create a `my-team.yaml` file:
```yaml
managerEmail: "estuary@example.com"
responsibilities: "mixing it up"
parentTeam:
  alias: "Team Brackish Water"
```

4. Run `opslevel create team angler-test-team -f my-team.yaml`

5. Update `parentTeam` in `my-team.yaml`

6. Run `opslevel update team angler-test-team -f my-team.yaml`