### PR TITLE
Db/export parent teams from terraform

### DIFF
--- a/.changes/unreleased/Feature-20231030-155711.yaml
+++ b/.changes/unreleased/Feature-20231030-155711.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add parent field to exported opslevel_team terraform resource
+time: 2023-10-30T15:57:11.071803-05:00

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -313,6 +313,7 @@ func exportTeams(c *opslevel.Client, config *os.File, shell *os.File) {
 	teamConfig := `resource "opslevel_team" "%s" {
   name = "%s"
   manager_email = "%s"
+  parent = "%s"
   %s
   %s
 }
@@ -325,7 +326,15 @@ func exportTeams(c *opslevel.Client, config *os.File, shell *os.File) {
 		if len(aliases) > 0 {
 			aliases = fmt.Sprintf("aliases = [\"%s\"]", aliases)
 		}
-		config.WriteString(templateConfig(teamConfig, team.Alias, team.Name, team.Manager.Email, aliases, buildMultilineStringArg("responsibilities", team.Responsibilities)))
+		config.WriteString(templateConfig(
+			teamConfig,
+			team.Alias,
+			team.Name,
+			team.Manager.Email,
+			team.ParentTeam.Alias,
+			aliases,
+			buildMultilineStringArg("responsibilities", team.Responsibilities),
+		))
 		shell.WriteString(fmt.Sprintf("terraform import opslevel_team.%s %s\n", team.Alias, team.Id))
 	}
 	shell.WriteString("##########\n\n")


### PR DESCRIPTION
## Issues

[#131](https://github.com/OpsLevel/team-platform/issues/131)

## Changelog

Terraform resource opslevel_team's `parent` field exported with `opslevel export terraform` command
- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

Run `opslevel export terraform` then inspect `terraform/opslevel_teams.tf` for `parent = "parent-team-name"` field