### PR TITLE
Db/deprecate groups

### DIFF
--- a/.changes/unreleased/Deprecated-20231031-155638.yaml
+++ b/.changes/unreleased/Deprecated-20231031-155638.yaml
@@ -1,0 +1,3 @@
+kind: Deprecated
+body: group commands deprecated in favor of Team hierarchies
+time: 2023-10-31T15:56:38.351074-05:00

--- a/.changes/unreleased/Deprecated-20231101-105247.yaml
+++ b/.changes/unreleased/Deprecated-20231101-105247.yaml
@@ -1,0 +1,3 @@
+kind: Deprecated
+body: '"opslevel import group" command is deprecated'
+time: 2023-11-01T10:52:47.479832-05:00

--- a/.changes/unreleased/Removed-20231101-104007.yaml
+++ b/.changes/unreleased/Removed-20231101-104007.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: '"opslevel import group" command has been removed'
+time: 2023-11-01T10:40:07.550406-05:00

--- a/.changes/unreleased/Removed-20231101-104007.yaml
+++ b/.changes/unreleased/Removed-20231101-104007.yaml
@@ -1,3 +1,0 @@
-kind: Removed
-body: '"opslevel import group" command has been removed'
-time: 2023-11-01T10:40:07.550406-05:00

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -16,7 +16,7 @@ var createGroupCmd = &cobra.Command{
 	Use:        "group",
 	Short:      "Create a group (deprecated). Use teams instead.",
 	Long:       `Create a group (deprecated). Use teams instead.`,
-	Deprecated: `Please use Teams instead.`,
+	Deprecated: `Please use Teams instead. See https://docs.opslevel.com/docs/groups`,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := errors.New("Groups are deprecated! Please use Teams instead.\nopslevel create team <args>")
 		cobra.CheckErr(err)
@@ -28,7 +28,7 @@ var getGroupCommand = &cobra.Command{
 	Aliases:    []string{"groups"},
 	Short:      "Get details about a group",
 	Long:       `Get details about a group`,
-	Deprecated: `Please convert this Group into a Team.`,
+	Deprecated: `Please convert this Group into a Team. See https://docs.opslevel.com/docs/groups`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -51,7 +51,7 @@ var getGroupMembersCommand = &cobra.Command{
 	Aliases:    []string{"members"},
 	Short:      "Get members for a group",
 	Long:       `The users who are members of the group.`,
-	Deprecated: `Please convert this Group into a Team.`,
+	Deprecated: `Please convert this Group into a Team. See https://docs.opslevel.com/docs/groups`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -85,7 +85,7 @@ var getGroupDescendantRepositoriesCommand = &cobra.Command{
 	Aliases:    []string{"repositories"},
 	Short:      "Get descendant repositories for a group",
 	Long:       `All the repositories that fall under this group - ex. this group's child repositories, all the child repositories of this group's descendants, etc.`,
-	Deprecated: `Please convert this Group into a Team.`,
+	Deprecated: `Please convert this Group into a Team. See https://docs.opslevel.com/docs/groups`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -119,7 +119,7 @@ var getGroupDescendantServicesCommand = &cobra.Command{
 	Aliases:    []string{"services"},
 	Short:      "Get descendant services for a group",
 	Long:       `All the services that fall under this group - ex. this group's child services, all the child services of this group's descendants, etc.`,
-	Deprecated: `Please convert this Group into a Team.`,
+	Deprecated: `Please convert this Group into a Team. See https://docs.opslevel.com/docs/groups`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -153,7 +153,7 @@ var getGroupDescendantSubgroupsCommand = &cobra.Command{
 	Aliases:    []string{"subgroups"},
 	Short:      "Get descendant subgroups for a group",
 	Long:       `All the groups that fall under this group - ex. this group's child groups, children of those groups, etc.`,
-	Deprecated: `Please convert this Group into a Team.`,
+	Deprecated: `Please convert this Group into a Team. See https://docs.opslevel.com/docs/groups`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -187,7 +187,7 @@ var getGroupDescendantTeamsCommand = &cobra.Command{
 	Aliases:    []string{"teams"},
 	Short:      "Get descendant teams for a group",
 	Long:       `All the teams that fall under this group - ex. this group's child teams, all the child teams of this group's descendants, etc.`,
-	Deprecated: `Please convert this parent Group into a Team.`,
+	Deprecated: `Please convert this parent Group into a Team. See https://docs.opslevel.com/docs/groups`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -221,7 +221,7 @@ var listGroupCmd = &cobra.Command{
 	Aliases:    []string{"groups"},
 	Short:      "Lists the groups",
 	Long:       `Lists the groups`,
-	Deprecated: `Please convert these Groups into Teams.`,
+	Deprecated: `Please convert these Groups into Teams. See https://docs.opslevel.com/docs/groups`,
 	Run: func(cmd *cobra.Command, args []string) {
 		resp, err := getClientGQL().ListGroups(nil)
 		list := resp.Nodes
@@ -242,7 +242,7 @@ var updateGroupCmd = &cobra.Command{
 	Use:        "group ID|ALIAS",
 	Short:      "Update a group",
 	Long:       `Update a group (deprecated). Use teams instead.`,
-	Deprecated: `Please convert this Group into a Team.`,
+	Deprecated: `Please convert this Group into a Team. See https://docs.opslevel.com/docs/groups`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -274,7 +274,7 @@ var importGroupsCmd = &cobra.Command{
 	Use:        "group",
 	Aliases:    []string{"groups"},
 	Short:      "Imports groups from a CSV",
-	Deprecated: `Please convert all Groups into Teams.`,
+	Deprecated: `Please convert all Groups into Teams. See https://docs.opslevel.com/docs/groups`,
 	Long: `Imports a list of groups from a CSV file with the column headers:
 Name,Description,Parent
 

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/opslevel/opslevel-go/v2023"
-	"github.com/rs/zerolog/log"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
@@ -273,40 +272,12 @@ var deleteGroupCmd = &cobra.Command{
 var importGroupsCmd = &cobra.Command{
 	Use:        "group",
 	Aliases:    []string{"groups"},
-	Short:      "Imports groups from a CSV",
-	Deprecated: `Please convert all Groups into Teams. See https://docs.opslevel.com/docs/groups`,
-	Long: `Imports a list of groups from a CSV file with the column headers:
-Name,Description,Parent
-
-Example:
-
-cat << EOF | opslevel import group -f -
-Name,Description,Parent
-Engineering,All of Engineering,
-Product,All of Product,engineering
-Sales,Sales BU,product
-EOF
-`,
+	Short:      "(Formerly) Imports groups from a CSV",
+	Long:       "(Formerly) Imports groups from a CSV",
+	Deprecated: `Groups are deprecated! Please use Teams instead. See https://docs.opslevel.com/docs/groups`,
 	Run: func(cmd *cobra.Command, args []string) {
-		reader, err := readImportFilepathAsCSV()
+		err := errors.New("Groups are deprecated! Please use Teams instead.\nopslevel import team <args>")
 		cobra.CheckErr(err)
-		for reader.Rows() {
-			name := reader.Text("Name")
-			input := opslevel.GroupInput{
-				Name:        name,
-				Description: reader.Text("Description"),
-			}
-			parent := reader.Text("Parent")
-			if parent != "" {
-				input.Parent = opslevel.NewIdentifier(parent)
-			}
-			group, err := getClientGQL().CreateGroup(input)
-			if err != nil {
-				log.Error().Err(err).Msgf("error creating group '%s'", name)
-				continue
-			}
-			log.Info().Msgf("created group '%s' with id '%s'", group.Name, group.Id)
-		}
 	},
 }
 

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -2,41 +2,24 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/rs/zerolog/log"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var createGroupCmd = &cobra.Command{
-	Use:   "group",
-	Short: "Create a group",
-	Long: `Create a group
-
-cat << EOF | opslevel create group -f -
-name: "My Group"
-description: "Hello World Group"
-parent:
-  alias: "my-other-group-alias"
-members:
-  - email: info@opslevel.com
-  - email: support@opslevel.com
-team:
-  - alias: "my-team-alias"
-  - id: "s90s90ewr0fgd09sdf"
-EOF
-`,
+	Use:        "group",
+	Short:      "Create a group (deprecated). Use teams instead.",
+	Long:       `Create a group (deprecated). Use teams instead.`,
+	Deprecated: `Please use Teams instead.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readGroupInput()
+		err := errors.New("Groups are deprecated! Please use Teams instead.\nopslevel create team <args>")
 		cobra.CheckErr(err)
-		result, err := getClientGQL().CreateGroup(*input)
-		cobra.CheckErr(err)
-		fmt.Println(result.Id)
 	},
 }
 
@@ -45,6 +28,7 @@ var getGroupCommand = &cobra.Command{
 	Aliases:    []string{"groups"},
 	Short:      "Get details about a group",
 	Long:       `Get details about a group`,
+	Deprecated: `Please convert this Group into a Team.`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -67,6 +51,7 @@ var getGroupMembersCommand = &cobra.Command{
 	Aliases:    []string{"members"},
 	Short:      "Get members for a group",
 	Long:       `The users who are members of the group.`,
+	Deprecated: `Please convert this Group into a Team.`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -100,6 +85,7 @@ var getGroupDescendantRepositoriesCommand = &cobra.Command{
 	Aliases:    []string{"repositories"},
 	Short:      "Get descendant repositories for a group",
 	Long:       `All the repositories that fall under this group - ex. this group's child repositories, all the child repositories of this group's descendants, etc.`,
+	Deprecated: `Please convert this Group into a Team.`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -133,6 +119,7 @@ var getGroupDescendantServicesCommand = &cobra.Command{
 	Aliases:    []string{"services"},
 	Short:      "Get descendant services for a group",
 	Long:       `All the services that fall under this group - ex. this group's child services, all the child services of this group's descendants, etc.`,
+	Deprecated: `Please convert this Group into a Team.`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -166,6 +153,7 @@ var getGroupDescendantSubgroupsCommand = &cobra.Command{
 	Aliases:    []string{"subgroups"},
 	Short:      "Get descendant subgroups for a group",
 	Long:       `All the groups that fall under this group - ex. this group's child groups, children of those groups, etc.`,
+	Deprecated: `Please convert this Group into a Team.`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -199,6 +187,7 @@ var getGroupDescendantTeamsCommand = &cobra.Command{
 	Aliases:    []string{"teams"},
 	Short:      "Get descendant teams for a group",
 	Long:       `All the teams that fall under this group - ex. this group's child teams, all the child teams of this group's descendants, etc.`,
+	Deprecated: `Please convert this parent Group into a Team.`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -228,10 +217,11 @@ var getGroupDescendantTeamsCommand = &cobra.Command{
 }
 
 var listGroupCmd = &cobra.Command{
-	Use:     "group",
-	Aliases: []string{"groups"},
-	Short:   "Lists the groups",
-	Long:    `Lists the groups`,
+	Use:        "group",
+	Aliases:    []string{"groups"},
+	Short:      "Lists the groups",
+	Long:       `Lists the groups`,
+	Deprecated: `Please convert these Groups into Teams.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		resp, err := getClientGQL().ListGroups(nil)
 		list := resp.Nodes
@@ -249,25 +239,15 @@ var listGroupCmd = &cobra.Command{
 }
 
 var updateGroupCmd = &cobra.Command{
-	Use:   "group ID|ALIAS",
-	Short: "Update a group",
-	Long: `Update a group
-
-cat << EOF | opslevel update group "my-group-alias" -f -
-description: My updated group description
-parent:
-  alias: "next-group-alias"
-EOF
-`,
+	Use:        "group ID|ALIAS",
+	Short:      "Update a group",
+	Long:       `Update a group (deprecated). Use teams instead.`,
+	Deprecated: `Please convert this Group into a Team.`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
-		key := args[0]
-		input, err := readGroupInput()
+		err := errors.New("Groups are deprecated! Please use Teams instead.\nopslevel update team <args>")
 		cobra.CheckErr(err)
-		group, err := getClientGQL().UpdateGroup(key, *input)
-		cobra.CheckErr(err)
-		fmt.Println(group.Id)
 	},
 }
 
@@ -291,9 +271,10 @@ var deleteGroupCmd = &cobra.Command{
 }
 
 var importGroupsCmd = &cobra.Command{
-	Use:     "group",
-	Aliases: []string{"groups"},
-	Short:   "Imports groups from a CSV",
+	Use:        "group",
+	Aliases:    []string{"groups"},
+	Short:      "Imports groups from a CSV",
+	Deprecated: `Please convert all Groups into Teams.`,
 	Long: `Imports a list of groups from a CSV file with the column headers:
 Name,Description,Parent
 
@@ -341,14 +322,4 @@ func init() {
 	updateCmd.AddCommand(updateGroupCmd)
 	deleteCmd.AddCommand(deleteGroupCmd)
 	importCmd.AddCommand(importGroupsCmd)
-}
-
-func readGroupInput() (*opslevel.GroupInput, error) {
-	readInputConfig()
-	evt := &opslevel.GroupInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/opslevel/opslevel-go/v2023"
-	"github.com/rs/zerolog/log"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
@@ -270,46 +269,6 @@ var deleteGroupCmd = &cobra.Command{
 	},
 }
 
-var importGroupsCmd = &cobra.Command{
-	Use:        "group",
-	Aliases:    []string{"groups"},
-	Short:      "Imports groups from a CSV",
-	Deprecated: `Please convert all Groups into Teams. See https://docs.opslevel.com/docs/groups`,
-	Long: `Imports a list of groups from a CSV file with the column headers:
-Name,Description,Parent
-
-Example:
-
-cat << EOF | opslevel import group -f -
-Name,Description,Parent
-Engineering,All of Engineering,
-Product,All of Product,engineering
-Sales,Sales BU,product
-EOF
-`,
-	Run: func(cmd *cobra.Command, args []string) {
-		reader, err := readImportFilepathAsCSV()
-		cobra.CheckErr(err)
-		for reader.Rows() {
-			name := reader.Text("Name")
-			input := opslevel.GroupInput{
-				Name:        name,
-				Description: reader.Text("Description"),
-			}
-			parent := reader.Text("Parent")
-			if parent != "" {
-				input.Parent = opslevel.NewIdentifier(parent)
-			}
-			group, err := getClientGQL().CreateGroup(input)
-			if err != nil {
-				log.Error().Err(err).Msgf("error creating group '%s'", name)
-				continue
-			}
-			log.Info().Msgf("created group '%s' with id '%s'", group.Name, group.Id)
-		}
-	},
-}
-
 func init() {
 	createCmd.AddCommand(createGroupCmd)
 	getCmd.AddCommand(getGroupCommand)
@@ -321,5 +280,4 @@ func init() {
 	listCmd.AddCommand(listGroupCmd)
 	updateCmd.AddCommand(updateGroupCmd)
 	deleteCmd.AddCommand(deleteGroupCmd)
-	importCmd.AddCommand(importGroupsCmd)
 }

--- a/src/cmd/group.go
+++ b/src/cmd/group.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/opslevel/opslevel-go/v2023"
+	"github.com/rs/zerolog/log"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
@@ -269,6 +270,46 @@ var deleteGroupCmd = &cobra.Command{
 	},
 }
 
+var importGroupsCmd = &cobra.Command{
+	Use:        "group",
+	Aliases:    []string{"groups"},
+	Short:      "Imports groups from a CSV",
+	Deprecated: `Please convert all Groups into Teams. See https://docs.opslevel.com/docs/groups`,
+	Long: `Imports a list of groups from a CSV file with the column headers:
+Name,Description,Parent
+
+Example:
+
+cat << EOF | opslevel import group -f -
+Name,Description,Parent
+Engineering,All of Engineering,
+Product,All of Product,engineering
+Sales,Sales BU,product
+EOF
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		reader, err := readImportFilepathAsCSV()
+		cobra.CheckErr(err)
+		for reader.Rows() {
+			name := reader.Text("Name")
+			input := opslevel.GroupInput{
+				Name:        name,
+				Description: reader.Text("Description"),
+			}
+			parent := reader.Text("Parent")
+			if parent != "" {
+				input.Parent = opslevel.NewIdentifier(parent)
+			}
+			group, err := getClientGQL().CreateGroup(input)
+			if err != nil {
+				log.Error().Err(err).Msgf("error creating group '%s'", name)
+				continue
+			}
+			log.Info().Msgf("created group '%s' with id '%s'", group.Name, group.Id)
+		}
+	},
+}
+
 func init() {
 	createCmd.AddCommand(createGroupCmd)
 	getCmd.AddCommand(getGroupCommand)
@@ -280,4 +321,5 @@ func init() {
 	listCmd.AddCommand(listGroupCmd)
 	updateCmd.AddCommand(updateGroupCmd)
 	deleteCmd.AddCommand(deleteGroupCmd)
+	importCmd.AddCommand(importGroupsCmd)
 }

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -105,9 +105,10 @@ opslevel create contact --type=email my-team team@example.com "Mailing List"`,
 )
 
 var createTeamTagCmd = &cobra.Command{
-	Use:   "tag",
-	Short: "Create a team tag",
-	Long:  `Create a team tag`,
+	Use:        "tag",
+	Short:      "Create a team tag",
+	Long:       `Create a team tag`,
+	Deprecated: `Please use \nopslevel create tag <args>`,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := errors.New("This command is deprecated! Please use \nopslevel create tag <args>")
 		cobra.CheckErr(err)
@@ -186,9 +187,10 @@ opslevel list team -o json | jq 'map((.Members.Nodes | map(.Email)))'
 }
 
 var getTeamTagCmd = &cobra.Command{
-	Use:   "tag",
-	Short: "Get a team's tag",
-	Long:  `Get a team's tag`,
+	Use:        "tag",
+	Short:      "Get a team's tag",
+	Long:       `Get a team's tag`,
+	Deprecated: `Please use \nopslevel get tag <args>`,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := errors.New("This command is deprecated! Please use \nopslevel get tag <args>")
 		cobra.CheckErr(err)
@@ -257,9 +259,10 @@ var deleteContactCmd = &cobra.Command{
 }
 
 var deleteTeamTagCmd = &cobra.Command{
-	Use:   "tag",
-	Short: "Delete a team's tag",
-	Long:  `Delete a team's tag`,
+	Use:        "tag",
+	Short:      "Delete a team's tag",
+	Long:       `Delete a team's tag`,
+	Deprecated: `Please use \nopslevel delete tag <args>`,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := errors.New("This command is deprecated! Please use \nopslevel delete tag <args>")
 		cobra.CheckErr(err)


### PR DESCRIPTION
## Issues

[#132](https://github.com/OpsLevel/team-platform/issues/132)

## Changelog

Deprecate `group` commands in favor of Team hierarchies.
`group create` and `group update` are no-ops. The other `group` commands direct devs to the docs and to use Teams.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
