### PR TITLE
update create,delete team membership cmds with TeamMembershipUserInput

### DIFF
--- a/.changes/unreleased/Feature-20231107-152728.yaml
+++ b/.changes/unreleased/Feature-20231107-152728.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: 'update create,delete team membership with TeamMembershipUserInput'
+time: 2023-11-07T15:27:28.537238-06:00

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -39,14 +39,15 @@ EOF`,
 }
 
 var createMemberCmd = &cobra.Command{
-	Use:        "member {TEAM_ID|TEAM_ALIAS} EMAIL",
+	Use:        "member {TEAM_ID|TEAM_ALIAS} EMAIL ROLE",
 	Short:      "Add a member to a team",
 	Example:    `opslevel create member my-team john@example.com`,
-	Args:       cobra.ExactArgs(2),
-	ArgAliases: []string{"TEAM_ID", "TEAM_ALIAS", "EMAIL"},
+	Args:       cobra.MinimumNArgs(2),
+	ArgAliases: []string{"TEAM_ID", "TEAM_ALIAS", "EMAIL", "ROLE"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
 		email := args[1]
+		role := common.GetArg(args, 2, "")
 
 		var team *opslevel.Team
 		var err error
@@ -58,9 +59,13 @@ var createMemberCmd = &cobra.Command{
 		cobra.CheckErr(err)
 		common.WasFound(team.Id == "", key)
 
-		_, addErr := getClientGQL().AddMember(&team.TeamId, email)
+		teamMembershipUserInput := opslevel.TeamMembershipUserInput{
+			User: opslevel.UserIdentifierInput{Email: email},
+			Role: role,
+		}
+		_, addErr := getClientGQL().AddMembers(&team.TeamId, teamMembershipUserInput)
 		cobra.CheckErr(addErr)
-		fmt.Printf("add member '%s' on team '%s'\n", email, team.Alias)
+		fmt.Printf("added member '%s' on team '%s'\n", email, team.Alias)
 	},
 }
 
@@ -238,7 +243,10 @@ var deleteMemberCmd = &cobra.Command{
 		cobra.CheckErr(err)
 		common.WasFound(team.Id == "", key)
 
-		_, removeErr := getClientGQL().RemoveMember(&team.TeamId, email)
+		teamMembershipUserInput := opslevel.TeamMembershipUserInput{
+			User: opslevel.UserIdentifierInput{Email: email},
+		}
+		_, removeErr := getClientGQL().RemoveMembers(&team.TeamId, teamMembershipUserInput)
 		cobra.CheckErr(removeErr)
 		fmt.Printf("member '%s' on team '%s' removed\n", email, key)
 	},

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -188,7 +188,11 @@ EOF
 					log.Error().Err(err).Msgf("error finding team '%s' for user '%s'", team, user.Email)
 					continue
 				}
-				_, err = getClientGQL().AddMember(&t.TeamId, user.Email)
+				newMembership := opslevel.TeamMembershipUserInput{
+					User: opslevel.UserIdentifierInput{Email: user.Email},
+					Role: string(user.Role),
+				}
+				_, err = getClientGQL().AddMember(&t.TeamId, newMembership)
 				if err != nil {
 					log.Error().Err(err).Msgf("error adding user '%s' to team '%s'", user.Email, t.Name)
 					continue


### PR DESCRIPTION
## Issues

[#133](https://github.com/OpsLevel/team-platform/issues/133)

NOTE: this PR depends on the code from [this opslevel-go PR](https://github.com/OpsLevel/opslevel-go/pull/288) being merged first. Along with a subsequent submodule commit hash update.

## Changelog

Team members can be assigned with roles

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```
# Create new team membership 
opslevel create member example-team dev@example.com

# Verify new team membership exists
opslevel get team example-team

# Remove new team membership 
opslevel delete member example-team

# Create new team membership (with role, defaults to 'contributor')
opslevel create member example-team dev@example.com manager

# Remove new team membership (again)
opslevel delete member example-team
```