### PR TITLE
Export Teams and team memberships to Terraform

### DIFF
--- a/.changes/unreleased/Bugfix-20231127-171854.yaml
+++ b/.changes/unreleased/Bugfix-20231127-171854.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix exporting Teams in Terraform to have up to have a schema compatible with
+  v0.8.13
+time: 2023-11-27T17:18:54.983105-05:00

--- a/.changes/unreleased/Feature-20231127-171923.yaml
+++ b/.changes/unreleased/Feature-20231127-171923.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Support for exporting Team Memberships in Terraform
+time: 2023-11-27T17:19:23.084993-05:00

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -96,13 +96,13 @@ provider "opslevel" {
 
 	graphqlClient := getClientGQL()
 
-	// exportConstants(graphqlClient, constants)
-	// exportRepos(graphqlClient, repos, bash)
-	// exportServices(graphqlClient, bash, directory)
+	exportConstants(graphqlClient, constants)
+	exportRepos(graphqlClient, repos, bash)
+	exportServices(graphqlClient, bash, directory)
 	exportTeams(graphqlClient, teams, bash)
-	// exportFilters(graphqlClient, filters, bash)
-	// exportRubric(graphqlClient, rubric, bash)
-	// exportChecks(graphqlClient, bash, directory)
+	exportFilters(graphqlClient, filters, bash)
+	exportRubric(graphqlClient, rubric, bash)
+	exportChecks(graphqlClient, bash, directory)
 	fmt.Println("Complete!")
 }
 

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -312,6 +312,7 @@ func exportTeams(c *opslevel.Client, config *os.File, shell *os.File) {
 
 	teamConfig := `resource "opslevel_team" "%s" {%s
 }
+
 `
 	resp, err := c.ListTeams(nil)
 	teams := resp.Nodes

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -308,13 +308,14 @@ func exportServices(c *opslevel.Client, shell *os.File, directory string) {
 }
 
 func getMembershipsAsTerraformConfig(members []opslevel.TeamMembership) string {
-	membersBody := strings.Builder{}
-	for _, member := range members {
-		memberConfig := `
+	memberConfig := `
   member {
     email = "%s"
     role = "%s"
   }`
+
+	membersBody := strings.Builder{}
+	for _, member := range members {
 		membersBody.WriteString(fmt.Sprintf(memberConfig, member.User.Email, member.Role))
 	}
 	return membersBody.String()

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -307,6 +307,19 @@ func exportServices(c *opslevel.Client, shell *os.File, directory string) {
 	}
 }
 
+func getMembershipsAsTerraformConfig(members []opslevel.TeamMembership) string {
+	membersBody := strings.Builder{}
+	for _, member := range members {
+		memberConfig := `
+  member {
+    email = "%s"
+    role = "%s"
+  }`
+		membersBody.WriteString(fmt.Sprintf(memberConfig, member.User.Email, member.Role))
+	}
+	return membersBody.String()
+}
+
 func exportTeams(c *opslevel.Client, config *os.File, shell *os.File) {
 	shell.WriteString("# Teams\n")
 
@@ -326,15 +339,7 @@ func exportTeams(c *opslevel.Client, config *os.File, shell *os.File) {
 		if len(team.Group.Alias) > 0 {
 			teamBody.WriteString(fmt.Sprintf("\n  group = \"%s\"", team.Group.Alias))
 		}
-		membersOutput := ""
-		for _, member := range team.Memberships.Nodes {
-			memberConfig := `
-  member {
-    email = "%s"
-    role = "%s"
-  }`
-			membersOutput += fmt.Sprintf(memberConfig, member.User.Email, member.Role)
-		}
+		membersOutput := getMembershipsAsTerraformConfig(team.Memberships.Nodes)
 		teamBody.WriteString(membersOutput)
 		if len(team.ParentTeam.Alias) > 0 {
 			teamBody.WriteString(fmt.Sprintf("\n  parent = [\"%s\"]", team.ParentTeam.Alias))

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -335,9 +335,7 @@ func exportTeams(c *opslevel.Client, config *os.File, shell *os.File) {
   }`
 			membersOutput += fmt.Sprintf(memberConfig, member.User.Email, member.Role)
 		}
-		if len(membersOutput) > 0 {
-			teamBody.WriteString(membersOutput)
-		}
+		teamBody.WriteString(membersOutput)
 		if len(team.ParentTeam.Alias) > 0 {
 			teamBody.WriteString(fmt.Sprintf("\n  parent = [\"%s\"]", team.ParentTeam.Alias))
 		}

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -310,8 +310,7 @@ func exportServices(c *opslevel.Client, shell *os.File, directory string) {
 func exportTeams(c *opslevel.Client, config *os.File, shell *os.File) {
 	shell.WriteString("# Teams\n")
 
-	teamConfig := `resource "opslevel_team" "%s" {
-%s
+	teamConfig := `resource "opslevel_team" "%s" {%s
 }
 `
 	resp, err := c.ListTeams(nil)
@@ -322,31 +321,31 @@ func exportTeams(c *opslevel.Client, config *os.File, shell *os.File) {
 
 		aliases := flattenAliases(team.Aliases)
 		if len(aliases) > 0 {
-			teamBody += fmt.Sprintf("  aliases = [\"%s\"]\n", aliases)
+			teamBody += fmt.Sprintf("\n  aliases = [\"%s\"]", aliases)
 		}
-		teamBody += fmt.Sprintf("  name = \"%s\"\n", team.Name)
+		teamBody += fmt.Sprintf("\n  name = \"%s\"", team.Name)
 
-		if team.Group.Alias != "" {
-			teamBody += fmt.Sprintf("  group = \"%s\"\n", team.Group.Alias)
+		if len(team.Group.Alias) > 0 {
+			teamBody += fmt.Sprintf("\n  group = \"%s\"", team.Group.Alias)
 		}
 		membersOutput := ""
 		for _, member := range team.Memberships.Nodes {
-			memberConfig := `  member {
+			memberConfig := `
+  member {
     email = "%s"
     role = "%s"
-  }
-`
+  }`
 			membersOutput += fmt.Sprintf(memberConfig, member.User.Email, member.Role)
 		}
 		if len(membersOutput) > 0 {
 			teamBody += membersOutput
 		}
-		if team.ParentTeam.Alias != "" {
-			teamBody += fmt.Sprintf("  parent = [\"%s\"]\n", team.ParentTeam.Alias)
+		if len(team.ParentTeam.Alias) > 0 {
+			teamBody += fmt.Sprintf("\n  parent = [\"%s\"]", team.ParentTeam.Alias)
 		}
-		responsibilities := buildMultilineStringArg("responsibilities", team.Responsibilities)
-		if len(responsibilities) > 0 {
-			teamBody += fmt.Sprintf("  %s", responsibilities)
+		if len(team.Responsibilities) > 0 {
+			responsibilities := buildMultilineStringArg("responsibilities", team.Responsibilities)
+			teamBody += fmt.Sprintf("\n  %s", responsibilities)
 		}
 
 		config.WriteString(templateConfig(


### PR DESCRIPTION
## Issues

After shipping https://github.com/OpsLevel/terraform-provider-opslevel/pull/144 some customers can be in a state where their terraform Team configs are not using the new `member { }` blocks. This results in Team Memberships not being able to reconcile without kicking all members out of the terraform managed teams.

[Also, the terraform export output is not compatible with the latest TF schema version.](https://registry.terraform.io/providers/OpsLevel/opslevel/0.8.13/docs/resources/team)

## Changelog

- [x] Change export team function
- [x] Minor changes: fix unnecessary line spaces, add line spaces between team resources to make it easier to read
- [x] Make a `changie` entry

## Tophatting

Before:

```
resource "opslevel_team" "platform" {
  name = "platform"
  manager_email = ""
  aliases = ["platform"]
  
}
resource "opslevel_team" "platform_2" {
  name = "Platform"
  manager_email = ""
  aliases = ["platform_2"]
  
}
```

After (places a line space between resources):

```
resource "opslevel_team" "platform" {
  aliases = ["platform"]
  name = "platform"
  member {
    email = "david+orange@opslevel.com"
    role = "contributor"
  }
  member {
    email = "kyle+orange@opslevel.com"
    role = "contributor"
  }
}

resource "opslevel_team" "platform_2" {
  aliases = ["platform_2"]
  name = "Platform"
  group = "platform"
  member {
    email = "taimoor+orange@opslevel.com"
    role = "contributor"
  }
  parent = ["engineering"]
}
```
