### PR TITLE
consolidate cli input read funcs into readResourceInput

### DIFF
--- a/.changes/unreleased/Feature-20231208-102655.yaml
+++ b/.changes/unreleased/Feature-20231208-102655.yaml
@@ -1,3 +1,0 @@
-kind: Feature
-body: consolidate cli input read funcs into readResourceInput
-time: 2023-12-08T10:26:55.311708-06:00

--- a/.changes/unreleased/Feature-20231208-102655.yaml
+++ b/.changes/unreleased/Feature-20231208-102655.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: consolidate cli input read funcs into readResourceInput
+time: 2023-12-08T10:26:55.311708-06:00

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -5,12 +5,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var actionType string
@@ -48,7 +46,7 @@ EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
 		switch actionType {
 		case "webhook":
-			input, err := readWebhookActionCreateInput()
+			input, err := readResourceInput[opslevel.CustomActionsWebhookActionCreateInput]()
 			cobra.CheckErr(err)
 			result, err := getClientGQL().CreateWebhookAction(*input)
 			cobra.CheckErr(err)
@@ -113,7 +111,7 @@ EOF`,
 		key := args[0]
 		switch actionType {
 		case "webhook":
-			input, err := readWebhookActionUpdateInput()
+			input, err := readResourceInput[opslevel.CustomActionsWebhookActionUpdateInput]()
 			input.Id = *opslevel.NewID(key)
 			cobra.CheckErr(err)
 			action, err := getClientGQL().UpdateWebhookAction(*input)
@@ -148,24 +146,4 @@ func init() {
 	getCmd.AddCommand(getActionCmd)
 	listCmd.AddCommand(listActionCmd)
 	deleteCmd.AddCommand(deleteActionCmd)
-}
-
-func readWebhookActionCreateInput() (*opslevel.CustomActionsWebhookActionCreateInput, error) {
-	readInputConfig()
-	evt := &opslevel.CustomActionsWebhookActionCreateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
-}
-
-func readWebhookActionUpdateInput() (*opslevel.CustomActionsWebhookActionUpdateInput, error) {
-	readInputConfig()
-	evt := &opslevel.CustomActionsWebhookActionUpdateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/dependency.go
+++ b/src/cmd/dependency.go
@@ -3,10 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // CLIServiceDependencyCreateInput This is used to make the user facing CLI experience better
@@ -59,7 +57,7 @@ func init() {
 }
 
 func readCreateServiceDependencyInput() (*opslevel.ServiceDependencyCreateInput, error) {
-	in, err := readDependencyInput()
+	in, err := readResourceInput[CLIServiceDependencyCreateInput]()
 	if err != nil {
 		return nil, err
 	}
@@ -71,14 +69,4 @@ func readCreateServiceDependencyInput() (*opslevel.ServiceDependencyCreateInput,
 		Notes: in.Notes,
 	}
 	return output, nil
-}
-
-func readDependencyInput() (*CLIServiceDependencyCreateInput, error) {
-	readInputConfig()
-	evt := &CLIServiceDependencyCreateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/domain.go
+++ b/src/cmd/domain.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var createDomainCmd = &cobra.Command{
@@ -28,7 +26,7 @@ note: "Additional details"
 EOF
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readDomainInput()
+		input, err := readResourceInput[opslevel.DomainInput]()
 		cobra.CheckErr(err)
 		result, err := getClientGQL().CreateDomain(*input)
 		cobra.CheckErr(err)
@@ -122,7 +120,7 @@ EOF
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		input, err := readDomainInput()
+		input, err := readResourceInput[opslevel.DomainInput]()
 		cobra.CheckErr(err)
 		domain, err := getClientGQL().UpdateDomain(key, *input)
 		cobra.CheckErr(err)
@@ -136,14 +134,4 @@ func init() {
 	getCmd.AddCommand(getDomainCmd)
 	listCmd.AddCommand(listDomainCmd)
 	updateCmd.AddCommand(updateDomainCmd)
-}
-
-func readDomainInput() (*opslevel.DomainInput, error) {
-	readInputConfig()
-	evt := &opslevel.DomainInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/filter.go
+++ b/src/cmd/filter.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var createFilterCmd = &cobra.Command{
@@ -30,7 +28,7 @@ predicates:
     value: "rds"
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readFilterInput()
+		input, err := readResourceInput[opslevel.FilterCreateInput]()
 		cobra.CheckErr(err)
 		result, err := getClientGQL().CreateFilter(*input)
 		cobra.CheckErr(err)
@@ -93,7 +91,7 @@ EOF`,
 	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readFilterInput()
+		input, err := readResourceInput[opslevel.FilterCreateInput]()
 		cobra.CheckErr(err)
 
 		// hack: in the future all ObjectUpdateInput and ObjectCreateInput
@@ -131,14 +129,4 @@ func init() {
 	getCmd.AddCommand(getFilterCmd)
 	listCmd.AddCommand(listFilterCmd)
 	deleteCmd.AddCommand(deleteFilterCmd)
-}
-
-func readFilterInput() (*opslevel.FilterCreateInput, error) {
-	readInputConfig()
-	evt := &opslevel.FilterCreateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/input.go
+++ b/src/cmd/input.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/creasty/defaults"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 var dataFile string
@@ -30,13 +31,31 @@ func readInputConfig() {
 }
 
 func readResourceInput[T any]() (*T, error) {
-	readInputConfig()
-	var evt T
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(&evt); err != nil {
+	var err error
+	var resource T
+	var yamlData []byte
+
+	switch dataFile {
+	case ".":
+		yamlData, err = os.ReadFile("./data.yaml")
+	case "-":
+		if isStdInFromTerminal() {
+			log.Info().Msg("Reading input directly from command line... Press CTRL+D to stop typing")
+		}
+		buf := bytes.Buffer{}
+		_, err = buf.ReadFrom(os.Stdin)
+		yamlData = buf.Bytes()
+	default:
+		yamlData, err = os.ReadFile(dataFile)
+	}
+	if err != nil {
 		return nil, err
 	}
-	return &evt, nil
+
+	if err := yaml.Unmarshal(yamlData, &resource); err != nil {
+		return nil, err
+	}
+	return &resource, nil
 }
 
 func isStdInFromTerminal() bool {

--- a/src/cmd/input.go
+++ b/src/cmd/input.go
@@ -31,12 +31,12 @@ func readInputConfig() {
 
 func readResourceInput[T any]() (*T, error) {
 	readInputConfig()
-	var evt *T
+	var evt T
 	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
+	if err := defaults.Set(&evt); err != nil {
 		return nil, err
 	}
-	return evt, nil
+	return &evt, nil
 }
 
 func isStdInFromTerminal() bool {

--- a/src/cmd/input.go
+++ b/src/cmd/input.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/creasty/defaults"
 	"github.com/spf13/viper"
 )
 
@@ -26,6 +27,16 @@ func readInputConfig() {
 		viper.SetConfigFile(dataFile)
 	}
 	viper.ReadInConfig()
+}
+
+func readResourceInput[T any]() (*T, error) {
+	readInputConfig()
+	var evt *T
+	viper.Unmarshal(&evt)
+	if err := defaults.Set(evt); err != nil {
+		return nil, err
+	}
+	return evt, nil
 }
 
 func isStdInFromTerminal() bool {

--- a/src/cmd/scorecard.go
+++ b/src/cmd/scorecard.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var createScorecardCmd = &cobra.Command{
@@ -24,7 +22,7 @@ ownerId: "XXX_team_id_XXX"
 affectsOverallServiceLevels: false
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readScorecardInput()
+		input, err := readResourceInput[opslevel.ScorecardInput]()
 		cobra.CheckErr(err)
 		result, err := getClientGQL().CreateScorecard(*input)
 		cobra.CheckErr(err)
@@ -85,7 +83,7 @@ EOF`,
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		input, err := readScorecardInput()
+		input, err := readResourceInput[opslevel.ScorecardInput]()
 		cobra.CheckErr(err)
 		scorecard, err := getClientGQL().UpdateScorecard(key, *input)
 		cobra.CheckErr(err)
@@ -113,14 +111,4 @@ func init() {
 	getCmd.AddCommand(getScorecardCmd)
 	listCmd.AddCommand(listScorecardCmd)
 	deleteCmd.AddCommand(deleteScorecardCmd)
-}
-
-func readScorecardInput() (*opslevel.ScorecardInput, error) {
-	readInputConfig()
-	evt := &opslevel.ScorecardInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/secret.go
+++ b/src/cmd/secret.go
@@ -4,14 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/creasty/defaults"
-
 	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/opslevel/cli/common"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var secretAlias string
@@ -27,7 +24,7 @@ owner:
 value: "my-really-secure-secret-shhhh"
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readSecretInput()
+		input, err := readResourceInput[opslevel.SecretInput]()
 		cobra.CheckErr(err)
 		newSecret, err := getClientGQL().CreateSecret(secretAlias, *input)
 		cobra.CheckErr(err)
@@ -92,7 +89,7 @@ EOF`,
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
 		secretId := args[0]
-		input, err := readSecretInput()
+		input, err := readResourceInput[opslevel.SecretInput]()
 		cobra.CheckErr(err)
 		secret, err := getClientGQL().UpdateSecret(secretId, *input)
 		cobra.CheckErr(err)
@@ -112,16 +109,6 @@ var deleteSecretCmd = &cobra.Command{
 		cobra.CheckErr(err)
 		fmt.Printf("deleted '%s' secret\n", secretId)
 	},
-}
-
-func readSecretInput() (*opslevel.SecretInput, error) {
-	readInputConfig()
-	evt := &opslevel.SecretInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }
 
 func init() {

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -12,10 +12,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var createServiceCmd = &cobra.Command{
@@ -34,7 +32,7 @@ owner:
   alias: "Platform"
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readServiceCreateInput()
+		input, err := readResourceInput[opslevel.ServiceCreateInput]()
 		cobra.CheckErr(err)
 		result, err := getClientGQL().CreateService(*input)
 		cobra.CheckErr(err)
@@ -128,7 +126,7 @@ description: "Hello World Service Updated"
 tier: "tier_3"
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readServiceUpdateInput()
+		input, err := readResourceInput[opslevel.ServiceUpdateInput]()
 		cobra.CheckErr(err)
 		service, err := getClientGQL().UpdateService(*input)
 		cobra.CheckErr(err)
@@ -242,24 +240,4 @@ func init() {
 	deleteServiceCmd.AddCommand(deleteServiceTagCmd)
 
 	importCmd.AddCommand(importServicesCmd)
-}
-
-func readServiceCreateInput() (*opslevel.ServiceCreateInput, error) {
-	readInputConfig()
-	evt := &opslevel.ServiceCreateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
-}
-
-func readServiceUpdateInput() (*opslevel.ServiceUpdateInput, error) {
-	readInputConfig()
-	evt := &opslevel.ServiceUpdateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/system.go
+++ b/src/cmd/system.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var createSystemCmd = &cobra.Command{
@@ -29,7 +27,7 @@ var createSystemCmd = &cobra.Command{
 		EOF
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readSystemInput()
+		input, err := readResourceInput[opslevel.SystemInput]()
 		cobra.CheckErr(err)
 		result, err := getClientGQL().CreateSystem(*input)
 		cobra.CheckErr(err)
@@ -106,7 +104,7 @@ var updateSystemCmd = &cobra.Command{
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		input, err := readSystemInput()
+		input, err := readResourceInput[opslevel.SystemInput]()
 		cobra.CheckErr(err)
 		system, err := getClientGQL().UpdateSystem(key, *input)
 		cobra.CheckErr(err)
@@ -137,14 +135,4 @@ func init() {
 	listCmd.AddCommand(listSystemCmd)
 	updateCmd.AddCommand(updateSystemCmd)
 	deleteCmd.AddCommand(deleteSystemCmd)
-}
-
-func readSystemInput() (*opslevel.SystemInput, error) {
-	readInputConfig()
-	evt := &opslevel.SystemInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/viper"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
@@ -29,7 +27,7 @@ EOF`,
 	ArgAliases: []string{"NAME"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		input, err := readTeamCreateInput()
+		input, err := readResourceInput[opslevel.TeamCreateInput]()
 		input.Name = key
 		cobra.CheckErr(err)
 		team, err := getClientGQL().CreateTeam(*input)
@@ -124,7 +122,7 @@ var updateTeamCmd = &cobra.Command{
 	Use:   "team {ID|ALIAS}",
 	Short: "Update a team",
 	Example: `
-cat << EOF | opslevel update team my-team" -f -
+cat << EOF | opslevel update team my-team -f -
 managerEmail: "manager@example.com""
 parentTeam:
   alias: "parent-team-2"
@@ -135,7 +133,7 @@ EOF
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		input, err := readTeamUpdateInput()
+		input, err := readResourceInput[opslevel.TeamUpdateInput]()
 		input.Id = opslevel.ID(key)
 		cobra.CheckErr(err)
 		team, err := getClientGQL().UpdateTeam(*input)
@@ -330,24 +328,4 @@ func init() {
 	importCmd.AddCommand(importTeamsCmd)
 
 	createContactCmd.Flags().StringVarP(&contactType, "type", "t", "slack", "The contact type. One of: slack|email|web [default: slack]")
-}
-
-func readTeamCreateInput() (*opslevel.TeamCreateInput, error) {
-	readInputConfig()
-	evt := &opslevel.TeamCreateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
-}
-
-func readTeamUpdateInput() (*opslevel.TeamUpdateInput, error) {
-	readInputConfig()
-	evt := &opslevel.TeamUpdateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -17,7 +17,7 @@ var createTeamCmd = &cobra.Command{
 	Short: "Create a team",
 	Example: `opslevel create team my-team
 
-cat << EOF | opslevel create team my-team" -f -
+cat << EOF | opslevel create team my-team -f -
 managerEmail: "manager@example.com"
 parentTeam:
   alias: "parent-team"

--- a/src/cmd/trigger_definition.go
+++ b/src/cmd/trigger_definition.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/opslevel-go/v2023"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var createTriggerDefinitionCmd = &cobra.Command{
@@ -46,7 +44,7 @@ responseTemplate: |
   {% endif %}
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readTriggerDefinitionCreateInput()
+		input, err := readResourceInput[opslevel.CustomActionsTriggerDefinitionCreateInput]()
 		cobra.CheckErr(err)
 		result, err := getClientGQL().CreateTriggerDefinition(*input)
 		cobra.CheckErr(err)
@@ -105,7 +103,7 @@ EOF`,
 	ArgAliases: []string{"ID"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		input, err := readTriggerDefinitionUpdateInput()
+		input, err := readResourceInput[opslevel.CustomActionsTriggerDefinitionUpdateInput]()
 		input.Id = *opslevel.NewID(key)
 		cobra.CheckErr(err)
 		triggerDefinition, err := getClientGQL().UpdateTriggerDefinition(*input)
@@ -134,24 +132,4 @@ func init() {
 	getCmd.AddCommand(getTriggerDefinitionCmd)
 	listCmd.AddCommand(listTriggerDefinitionCmd)
 	deleteCmd.AddCommand(deleteTriggerDefinitionCmd)
-}
-
-func readTriggerDefinitionCreateInput() (*opslevel.CustomActionsTriggerDefinitionCreateInput, error) {
-	readInputConfig()
-	evt := &opslevel.CustomActionsTriggerDefinitionCreateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
-}
-
-func readTriggerDefinitionUpdateInput() (*opslevel.CustomActionsTriggerDefinitionUpdateInput, error) {
-	readInputConfig()
-	evt := &opslevel.CustomActionsTriggerDefinitionUpdateInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -8,12 +8,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var createUserCmd = &cobra.Command{
@@ -62,7 +60,7 @@ EOF
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		input, err := readUserInput()
+		input, err := readResourceInput[opslevel.UserInput]()
 		cobra.CheckErr(err)
 		filter, err := getClientGQL().UpdateUser(key, *input)
 		cobra.CheckErr(err)
@@ -213,14 +211,4 @@ func init() {
 	listCmd.AddCommand(listUserCmd)
 	deleteCmd.AddCommand(deleteUserCmd)
 	importCmd.AddCommand(importUsersCmd)
-}
-
-func readUserInput() (*opslevel.UserInput, error) {
-	readInputConfig()
-	evt := &opslevel.UserInput{}
-	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	return evt, nil
 }

--- a/src/common/client.go
+++ b/src/common/client.go
@@ -11,10 +11,13 @@ import (
 
 func NewGraphClient(version string, options ...opslevel.Option) *opslevel.Client {
 	timeout := time.Second * time.Duration(viper.GetInt("api-timeout"))
-	options = append(options, opslevel.SetAPIToken(viper.GetString("api-token")))
-	options = append(options, opslevel.SetURL(viper.GetString("api-url")))
-	options = append(options, opslevel.SetTimeout(timeout))
-	options = append(options, opslevel.SetUserAgentExtra(fmt.Sprintf("cli-%s", version)))
+	options = append(
+		options,
+		opslevel.SetAPIToken(viper.GetString("api-token")),
+		opslevel.SetURL(viper.GetString("api-url")),
+		opslevel.SetTimeout(timeout),
+		opslevel.SetUserAgentExtra(fmt.Sprintf("cli-%s", version)),
+	)
 	client := opslevel.NewGQLClient(options...)
 
 	clientErr := client.Validate()


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

- Consolidate similar readThing() funcs into `readResourceInput()` at [src/cmd/input.go](https://github.com/OpsLevel/cli/compare/db/unify-read-cli-input-to-readResourceInput?expand=1#diff-03faa53a7613111d9e5a128a4cd786a590a5278c48fbde3d50558ffa4e8e902e)
```go
func readResourceInput[T any]() (*T, error) {
	readInputConfig()
	var evt *T
	viper.Unmarshal(&evt)
	if err := defaults.Set(evt); err != nil {
		return nil, err
	}
	return evt, nil
}
```

- A change similar to below is applied in multiple places:
```diff
- input, err := readWebhookActionCreateInput()
+ input, err := readResourceInput[opslevel.CustomActionsWebhookActionCreateInput]()
```
- The defunct readThing() funcs were then removed

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

Manual test commands: 
```bash
# In orange
TEAM_ID=$(opslevel get team tf_baz | jq .Id | tr -d '"')
opslevel update team $TEAM_ID -f -
responsibilities: "work on many things"
^D

opslevel get team tf_baz | jq .Responsibilities
```
