### PR TITLE
update deprecated goreleaser args and yml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:
-          args: release --rm-dist --release-notes=../.changes/${{ steps.version.outputs.RELEASE_VERSION }}.md
+          args: release --clean --release-notes=../.changes/${{ steps.version.outputs.RELEASE_VERSION }}.md
           workdir: ./src
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -49,7 +49,7 @@ brews:
       bin.install "opslevel"
     test: |
       system "#{bin}/opslevel version"
-    tap:
+    repository:
       owner: opslevel
       name: homebrew-tap
       token: "{{ .Env.ORG_GITHUB_TOKEN }}"


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Update deprecated goreleaser args and setting. See [previous release job](https://github.com/OpsLevel/cli/actions/runs/7250382285/job/19750430459) and search `DEPRECATED`

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
