### PR TITLE
add dependabot gitsubmodule check for end of week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "src/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gitsubmodule"
+    directory: "src/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "10:00"
+      timezone: "America/New_York"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/dist
 .idea
 .DS_Store
 go.work*
+**coverage.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/submodules/opslevel-go"]
 	path = src/submodules/opslevel-go
 	url = git@github.com:OpsLevel/opslevel-go.git
-  branch = main
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/submodules/opslevel-go"]
 	path = src/submodules/opslevel-go
 	url = git@github.com:OpsLevel/opslevel-go.git
+  branch = main

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,6 +55,7 @@ tasks:
       - cmd: echo "Setting up opslevel-go workspace..."
         silent: true
       - git submodule update --init
+      - git submodule update --remote
       - go work init || exit 0
       - go work use . submodules/opslevel-go
       - cmd: echo "opslevel-go workspace ready!"


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add [gitsubmodule check](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) to `dependabot` config as an extra reminder to update submodules at the end of the week. This can help ensure the cli stays up to date with the latest opslevel-go code

Setting `branch = main` in `.gitmodules` lets `task setup` use `git submodule update --remote` to always get the latest commit from `main`

- [X] List your changes here
- [ ] Make a `changie` entry, N/A

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
