### PR TITLE
add create,get,list,delete PropertyDefinitions capabilities

### DIFF
--- a/.changes/unreleased/Feature-20231221-160003.yaml
+++ b/.changes/unreleased/Feature-20231221-160003.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add create,get,list,delete PropertyDefinitions capabilities
+time: 2023-12-21T16:00:03.960055-06:00

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -1,102 +1,132 @@
 package cmd
 
-// import (
-// 	"encoding/json"
-// 	"fmt"
+import (
+	"encoding/json"
+	"fmt"
 
-// 	"github.com/opslevel/opslevel-go/v2023"
+	"github.com/opslevel/opslevel-go/v2023"
 
-// 	"github.com/opslevel/cli/common"
+	"github.com/opslevel/cli/common"
 
-// 	"github.com/spf13/cobra"
-// )
+	"github.com/spf13/cobra"
+)
 
-// var examplePropertyDefinitionCmd = &cobra.Command{
-// 	Use:   "property-definition",
-// 	Short: "Example Property Definition",
-// 	Long:  `Example Property Definition`,
-// 	Run: func(cmd *cobra.Command, args []string) {
-// 		fmt.Println(getExample[opslevel.PropertyDefinitionInput]())
-// 	},
-// }
+var examplePropertyDefinitionCmd = &cobra.Command{
+	Use:   "property-definition",
+	Short: "Example Property Definition",
+	Long:  `Example Property Definition`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(getExample[opslevel.PropertyDefinitionInput]())
+	},
+}
 
-// var createPropertyDefinitonCmd = &cobra.Command{
-// 	Use:   "property-definition",
-// 	Short: "Create a property-definition",
-// 	Long:  `Create a property-definition`,
-// 	Example: fmt.Sprintf(`
-// cat << EOF | opslevel create property-definition -f -
-// %s
-// EOF`, getYaml[opslevel.PropertyDefinitionInput]()),
-// 	Run: func(cmd *cobra.Command, args []string) {
-// 		input, err := readResourceInput[opslevel.PropertyDefinitionInput]()
-// 		cobra.CheckErr(err)
-// 		newPropertyDefinition, err := getClientGQL().CreatePropertyDefinition(*input)
-// 		cobra.CheckErr(err)
+var createPropertyDefinitonCmd = &cobra.Command{
+	Use:   "property-definition",
+	Short: "Create a property-definition",
+	Long:  `Create a property-definition`,
+	Example: fmt.Sprintf(`
+cat << EOF | opslevel create property-definition -f -
+%s
+EOF`, getYaml[opslevel.PropertyDefinitionInput]()),
+	Run: func(cmd *cobra.Command, args []string) {
+		input, err := readPropertyDefinitionInput()
+		cobra.CheckErr(err)
+		newPropertyDefinition, err := getClientGQL().CreatePropertyDefinition(*input)
+		cobra.CheckErr(err)
 
-// 		fmt.Println(newPropertyDefinition.Id)
-// 	},
-// }
+		fmt.Println(newPropertyDefinition.Id)
+	},
+}
 
-// var getPropertyDefinition = &cobra.Command{
-// 	Use:        "property-definition",
-// 	Short:      "Get details about a property definition",
-// 	Long:       `Get details about a property definition`,
-// 	Args:       cobra.ExactArgs(1),
-// 	ArgAliases: []string{"ID"},
-// 	Run: func(cmd *cobra.Command, args []string) {
-// 		identifier := args[0]
-// 		result, err := getClientGQL().GetPropertyDefinition(identifier)
-// 		cobra.CheckErr(err)
+// The schema in PropertyDefinitionInput can be a nested map[string]any and needs to be handled separately
+func readPropertyDefinitionInput() (*opslevel.PropertyDefinitionInput, error) {
+	d, err := readResourceInput[map[string]any]()
+	if err != nil {
+		return nil, err
+	}
+	data := *d
+	name, ok := data["name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("name is required and must be a string")
+	}
+	schema, ok := data["schema"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema is required and must be a JSON object")
+	}
+	propDefInput := opslevel.PropertyDefinitionInput{
+		Name:   name,
+		Schema: opslevel.JSON(schema),
+	}
 
-// 		if isYamlOutput() {
-// 			common.YamlPrint(result)
-// 		} else {
-// 			common.PrettyPrint(result)
-// 		}
-// 	},
-// }
+	if description, ok := data["description"].(string); !ok {
+		propDefInput.Description = description
+	}
+	if propertyDisplayStatus, ok := data["propertyDisplayStatus"].(string); !ok {
+		propDefInput.PropertyDisplayStatus = opslevel.PropertyDisplayStatusEnum(propertyDisplayStatus)
+	}
 
-// var listPropertyDefinitionsCmd = &cobra.Command{
-// 	Use:     "property-definition",
-// 	Short:   "List property definitions",
-// 	Aliases: []string{"property-definitions"},
-// 	Long:    "List property definitions",
-// 	Run: func(cmd *cobra.Command, args []string) {
-// 		resp, err := getClientGQL().ListPropertyDefinitions(nil)
-// 		list := resp.Nodes
+	return &propDefInput, nil
+}
 
-// 		cobra.CheckErr(err)
-// 		if isJsonOutput() {
-// 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
-// 		} else {
-// 			w := common.NewTabWriter("ALIASES", "ID", "NAME", "SCHEMA")
-// 			for _, item := range list {
-// 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", item.Aliases, item.Id, item.Name, item.Schema.ToJSON())
-// 			}
-// 			w.Flush()
-// 		}
-// 	},
-// }
+var getPropertyDefinition = &cobra.Command{
+	Use:        "property-definition",
+	Short:      "Get details about a property definition",
+	Long:       `Get details about a property definition`,
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		identifier := args[0]
+		result, err := getClientGQL().GetPropertyDefinition(identifier)
+		cobra.CheckErr(err)
 
-// var deletePropertyDefinitonCmd = &cobra.Command{
-// 	Use:        "property-definition ID",
-// 	Short:      "Delete a property definitions",
-// 	Long:       "Delete a property definitions",
-// 	Args:       cobra.ExactArgs(1),
-// 	ArgAliases: []string{"ID"},
-// 	Run: func(cmd *cobra.Command, args []string) {
-// 		propertyDefinitionId := args[0]
-// 		err := getClientGQL().DeletePropertyDefinition(propertyDefinitionId)
-// 		cobra.CheckErr(err)
-// 		fmt.Printf("deleted property definition '%s'\n", propertyDefinitionId)
-// 	},
-// }
+		if isYamlOutput() {
+			common.YamlPrint(result)
+		} else {
+			common.PrettyPrint(result)
+		}
+	},
+}
 
-// func init() {
-// 	exampleCmd.AddCommand(examplePropertyDefinitionCmd)
-// 	createCmd.AddCommand(createPropertyDefinitonCmd)
-// 	getCmd.AddCommand(getPropertyDefinition)
-// 	listCmd.AddCommand(listPropertyDefinitionsCmd)
-// 	deleteCmd.AddCommand(deletePropertyDefinitonCmd)
-// }
+var listPropertyDefinitionsCmd = &cobra.Command{
+	Use:     "property-definition",
+	Short:   "List property definitions",
+	Aliases: []string{"property-definitions"},
+	Long:    "List property definitions",
+	Run: func(cmd *cobra.Command, args []string) {
+		resp, err := getClientGQL().ListPropertyDefinitions(nil)
+		list := resp.Nodes
+
+		cobra.CheckErr(err)
+		if isJsonOutput() {
+			common.JsonPrint(json.MarshalIndent(list, "", "    "))
+		} else {
+			w := common.NewTabWriter("ALIASES", "ID", "NAME", "SCHEMA")
+			for _, item := range list {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", item.Aliases, item.Id, item.Name, item.Schema.ToJSON())
+			}
+			w.Flush()
+		}
+	},
+}
+
+var deletePropertyDefinitonCmd = &cobra.Command{
+	Use:        "property-definition ID",
+	Short:      "Delete a property definitions",
+	Long:       "Delete a property definitions",
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		propertyDefinitionId := args[0]
+		err := getClientGQL().DeletePropertyDefinition(propertyDefinitionId)
+		cobra.CheckErr(err)
+		fmt.Printf("deleted property definition '%s'\n", propertyDefinitionId)
+	},
+}
+
+func init() {
+	exampleCmd.AddCommand(examplePropertyDefinitionCmd)
+	createCmd.AddCommand(createPropertyDefinitonCmd)
+	getCmd.AddCommand(getPropertyDefinition)
+	listCmd.AddCommand(listPropertyDefinitionsCmd)
+	deleteCmd.AddCommand(deletePropertyDefinitonCmd)
+}


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Manage PropertyDefinitions with the cli

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```bash
opslevel create property-definition -f <(opslevel example property-definition)
# ID returned
opslevel get property-definition <ID>
opslevel list property-definitions
opslevel delete property-definition <ID>
```
