### PR TITLE
add assign command, can assign property to services

### DIFF
--- a/.changes/unreleased/Feature-20231227-110844.yaml
+++ b/.changes/unreleased/Feature-20231227-110844.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add assign command, can assign property to services
+time: 2023-12-27T11:08:44.083678-06:00

--- a/.changes/unreleased/Feature-20231227-110844.yaml
+++ b/.changes/unreleased/Feature-20231227-110844.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: add assign command, can assign property to services
+body: add assign & unassign commands, can assign & unassign property to/from services
 time: 2023-12-27T11:08:44.083678-06:00

--- a/.changes/unreleased/Feature-20231227-110844.yaml
+++ b/.changes/unreleased/Feature-20231227-110844.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: add assign & unassign commands, can assign & unassign property to/from services
+body: add support for assigning, unassigning and reading Properties on Services
 time: 2023-12-27T11:08:44.083678-06:00

--- a/.changes/unreleased/Feature-20231227-114253.yaml
+++ b/.changes/unreleased/Feature-20231227-114253.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add get property command, gets assigned property
+time: 2023-12-27T11:42:53.880612-06:00

--- a/.changes/unreleased/Feature-20231227-145903.yaml
+++ b/.changes/unreleased/Feature-20231227-145903.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add support for listing Properties on a Service
+time: 2023-12-27T14:59:03.118701-05:00

--- a/src/cmd/assign.go
+++ b/src/cmd/assign.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var assignCmd = &cobra.Command{
+	Use:   "assign",
+	Short: "Assign properties to resources",
+	Long:  "Assign properties to resources",
+}
+
+func init() {
+	rootCmd.AddCommand(assignCmd)
+
+	assignCmd.PersistentFlags().StringVarP(&dataFile, "file", "f", "-", "File to read data from. If '.' then reads from './data.yaml'. Defaults to reading from stdin.")
+	viper.BindPFlags(assignCmd.Flags())
+}

--- a/src/cmd/assign.go
+++ b/src/cmd/assign.go
@@ -11,8 +11,15 @@ var assignCmd = &cobra.Command{
 	Long:  "Assign properties to resources",
 }
 
+var unassignCmd = &cobra.Command{
+	Use:   "unassign",
+	Short: "Unassign properties from resources",
+	Long:  "Unassign properties from resources",
+}
+
 func init() {
 	rootCmd.AddCommand(assignCmd)
+	rootCmd.AddCommand(unassignCmd)
 
 	assignCmd.PersistentFlags().StringVarP(&dataFile, "file", "f", "-", "File to read data from. If '.' then reads from './data.yaml'. Defaults to reading from stdin.")
 	viper.BindPFlags(assignCmd.Flags())

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -60,7 +60,7 @@ EOF`, getYaml[opslevel.PropertyInput]()),
 		newProperty, err := getClientGQL().PropertyAssign(*input)
 		cobra.CheckErr(err)
 
-		fmt.Printf("assigned property '%s' on '%s'\n", newProperty.Definition.Id, newProperty.Owner.Id)
+		fmt.Printf("assigned property '%s' on '%s'\n", newProperty.Definition.Id, newProperty.Owner.Id())
 	},
 }
 

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -46,6 +46,41 @@ var getPropertyCmd = &cobra.Command{
 	},
 }
 
+var listPropertyCmd = &cobra.Command{
+	Use:        "property",
+	Short:      "List properties on a Service",
+	Aliases:    []string{"propertys", "properties"},
+	Long:       "List properties on a Service identified by ID or Alias",
+	Args:       cobra.ExactArgs(1),
+	ArgAliases: []string{"SERVICE_ID", "SERVICE_ALIAS"},
+	Run: func(cmd *cobra.Command, args []string) {
+		var service *opslevel.Service
+		var err error
+		if opslevel.IsID(args[0]) {
+			service, err = getClientGQL().GetService(*opslevel.NewID(args[0]))
+		} else {
+			service, err = getClientGQL().GetServiceWithAlias(args[0])
+		}
+		cobra.CheckErr(err)
+		properties, err := service.GetProperties(getClientGQL(), nil)
+		cobra.CheckErr(err)
+
+		if isJsonOutput() {
+			common.JsonPrint(json.MarshalIndent(properties.Nodes, "", "    "))
+		} else {
+			w := common.NewTabWriter("DEFINITION_ID", "VALUE", "LEN_VALIDATION_ERRORS")
+			for _, prop := range properties.Nodes {
+				var valueOutput string
+				if prop.Value != nil {
+					valueOutput = string(*prop.Value)
+				}
+				fmt.Fprintf(w, "%s\t%s\t%d\n", string(prop.Definition.Id), valueOutput, len(prop.ValidationErrors))
+			}
+			w.Flush()
+		}
+	},
+}
+
 var assignPropertyCmd = &cobra.Command{
 	Use:   "property",
 	Short: "Assign a Property",
@@ -225,6 +260,7 @@ func init() {
 	assignCmd.AddCommand(assignPropertyCmd)
 	unassignCmd.AddCommand(unassignPropertyCmd)
 	getCmd.AddCommand(getPropertyCmd)
+	listCmd.AddCommand(listPropertyCmd)
 
 	// Property Definition Commands
 	exampleCmd.AddCommand(examplePropertyDefinitionCmd)

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -11,6 +11,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var examplePropertyCmd = &cobra.Command{
+	Use:   "property",
+	Short: "Example Property",
+	Long:  `Example Property`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(getExample[opslevel.PropertyInput]())
+	},
+}
+
+var assignPropertyCmd = &cobra.Command{
+	Use:   "property",
+	Short: "Assign a Property",
+	Long:  `Assign a Property`,
+	Example: fmt.Sprintf(`
+cat << EOF | opslevel assign property-definition -f -
+%s
+EOF`, getYaml[opslevel.PropertyInput]()),
+	Run: func(cmd *cobra.Command, args []string) {
+		input, err := readResourceInput[opslevel.PropertyInput]()
+		cobra.CheckErr(err)
+		newProperty, err := getClientGQL().PropertyAssign(*input)
+		cobra.CheckErr(err)
+
+		fmt.Println(newProperty.Definition.Id)
+	},
+}
+
 var examplePropertyDefinitionCmd = &cobra.Command{
 	Use:   "property-definition",
 	Short: "Example Property Definition",
@@ -93,7 +120,7 @@ func readPropertyDefinitionInput() (*opslevel.PropertyDefinitionInput, error) {
 	return &propDefInput, nil
 }
 
-var getPropertyDefinition = &cobra.Command{
+var getPropertyDefinitionCmd = &cobra.Command{
 	Use:        "property-definition",
 	Short:      "Get details about a property definition",
 	Long:       `Get details about a property definition`,
@@ -149,10 +176,15 @@ var deletePropertyDefinitonCmd = &cobra.Command{
 }
 
 func init() {
+	// Property Commands
+	exampleCmd.AddCommand(examplePropertyCmd)
+	assignCmd.AddCommand(assignPropertyCmd)
+
+	// Property Definition Commands
 	exampleCmd.AddCommand(examplePropertyDefinitionCmd)
 	createCmd.AddCommand(createPropertyDefinitonCmd)
 	updateCmd.AddCommand(updatePropertyDefinitonCmd)
-	getCmd.AddCommand(getPropertyDefinition)
+	getCmd.AddCommand(getPropertyDefinitionCmd)
 	listCmd.AddCommand(listPropertyDefinitionsCmd)
 	deleteCmd.AddCommand(deletePropertyDefinitonCmd)
 }

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -56,7 +56,7 @@ EOF`, getYaml[opslevel.PropertyInput]()),
 		newProperty, err := getClientGQL().PropertyAssign(*input)
 		cobra.CheckErr(err)
 
-		fmt.Println(newProperty.Definition.Id)
+		fmt.Printf("assigned property '%s' on '%s'\n", newProperty.Definition.Id, newProperty.Owner.Id)
 	},
 }
 

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -20,6 +20,28 @@ var examplePropertyCmd = &cobra.Command{
 	},
 }
 
+var getPropertyCmd = &cobra.Command{
+	Use:        "property",
+	Short:      "Get details about an assigned property",
+	Long:       `Get details about an assigned property`,
+	Example:    `opslevel get property owner-alias property-id`,
+	Args:       cobra.ExactArgs(2),
+	ArgAliases: []string{"ID", "ALIAS"},
+	Run: func(cmd *cobra.Command, args []string) {
+		ownerId := args[0]
+		propertyId := args[1]
+
+		result, err := getClientGQL().GetProperty(ownerId, propertyId)
+		cobra.CheckErr(err)
+
+		if isYamlOutput() {
+			common.YamlPrint(result)
+		} else {
+			common.PrettyPrint(result)
+		}
+	},
+}
+
 var assignPropertyCmd = &cobra.Command{
 	Use:   "property",
 	Short: "Assign a Property",
@@ -44,7 +66,7 @@ var unassignPropertyCmd = &cobra.Command{
 	Long:       `Unassign a Property from an Owner by Id or Alias`,
 	Example:    `opslevel unassign property owner-alias property-id`,
 	Args:       cobra.ExactArgs(2),
-	ArgAliases: []string{"OWNER_ID", "PROPERTY_ID"},
+	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		ownerId := args[0]
 		propertyId := args[1]
@@ -198,6 +220,7 @@ func init() {
 	exampleCmd.AddCommand(examplePropertyCmd)
 	assignCmd.AddCommand(assignPropertyCmd)
 	unassignCmd.AddCommand(unassignPropertyCmd)
+	getCmd.AddCommand(getPropertyCmd)
 
 	// Property Definition Commands
 	exampleCmd.AddCommand(examplePropertyDefinitionCmd)

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -126,7 +126,7 @@ var examplePropertyDefinitionCmd = &cobra.Command{
 	},
 }
 
-var createPropertyDefinitonCmd = &cobra.Command{
+var createPropertyDefinitionCmd = &cobra.Command{
 	Use:   "property-definition",
 	Short: "Create a property-definition",
 	Long:  `Create a property-definition`,
@@ -144,7 +144,7 @@ EOF`, getYaml[opslevel.PropertyDefinitionInput]()),
 	},
 }
 
-var updatePropertyDefinitonCmd = &cobra.Command{
+var updatePropertyDefinitionCmd = &cobra.Command{
 	Use:   "property-definition",
 	Short: "Update a property-definition",
 	Long:  `Update a property-definition`,
@@ -240,7 +240,7 @@ var listPropertyDefinitionsCmd = &cobra.Command{
 	},
 }
 
-var deletePropertyDefinitonCmd = &cobra.Command{
+var deletePropertyDefinitionCmd = &cobra.Command{
 	Use:        "property-definition ID",
 	Short:      "Delete a property definitions",
 	Long:       "Delete a property definitions",
@@ -264,9 +264,9 @@ func init() {
 
 	// Property Definition Commands
 	exampleCmd.AddCommand(examplePropertyDefinitionCmd)
-	createCmd.AddCommand(createPropertyDefinitonCmd)
-	updateCmd.AddCommand(updatePropertyDefinitonCmd)
+	createCmd.AddCommand(createPropertyDefinitionCmd)
+	updateCmd.AddCommand(updatePropertyDefinitionCmd)
 	getCmd.AddCommand(getPropertyDefinitionCmd)
 	listCmd.AddCommand(listPropertyDefinitionsCmd)
-	deleteCmd.AddCommand(deletePropertyDefinitonCmd)
+	deleteCmd.AddCommand(deletePropertyDefinitionCmd)
 }

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -33,6 +33,10 @@ var getPropertyCmd = &cobra.Command{
 
 		result, err := getClientGQL().GetProperty(ownerId, propertyId)
 		cobra.CheckErr(err)
+		if result.Definition.Id == "" && result.Owner.Id() == "" {
+			err = fmt.Errorf("property '%s' on entity '%s' not found\n", propertyId, ownerId)
+			cobra.CheckErr(err)
+		}
 
 		if isYamlOutput() {
 			common.YamlPrint(result)

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -84,7 +84,7 @@ var listPropertyCmd = &cobra.Command{
 var assignPropertyCmd = &cobra.Command{
 	Use:   "property",
 	Short: "Assign a Property",
-	Long:  `Assign a Property`,
+	Long:  `Assign a Property to an Entity by Id or Alias`,
 	Example: fmt.Sprintf(`
 cat << EOF | opslevel assign property-definition -f -
 %s
@@ -102,7 +102,7 @@ EOF`, getYaml[opslevel.PropertyInput]()),
 var unassignPropertyCmd = &cobra.Command{
 	Use:        "property",
 	Short:      "Unassign a Property",
-	Long:       `Unassign a Property from an Owner by Id or Alias`,
+	Long:       `Unassign a Property from an Entity by Id or Alias`,
 	Example:    `opslevel unassign property owner-alias property-id`,
 	Args:       cobra.ExactArgs(2),
 	ArgAliases: []string{"ID", "ALIAS"},

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -38,6 +38,24 @@ EOF`, getYaml[opslevel.PropertyInput]()),
 	},
 }
 
+var unassignPropertyCmd = &cobra.Command{
+	Use:        "property",
+	Short:      "Unassign a Property",
+	Long:       `Unassign a Property from an Owner by Id or Alias`,
+	Example:    `opslevel unassign property owner-alias property-id`,
+	Args:       cobra.ExactArgs(2),
+	ArgAliases: []string{"OWNER_ID", "PROPERTY_ID"},
+	Run: func(cmd *cobra.Command, args []string) {
+		ownerId := args[0]
+		propertyId := args[1]
+
+		err := getClientGQL().PropertyUnassign(ownerId, propertyId)
+		cobra.CheckErr(err)
+
+		fmt.Printf("unassigned property '%s' from '%s'\n", propertyId, ownerId)
+	},
+}
+
 var examplePropertyDefinitionCmd = &cobra.Command{
 	Use:   "property-definition",
 	Short: "Example Property Definition",
@@ -179,6 +197,7 @@ func init() {
 	// Property Commands
 	exampleCmd.AddCommand(examplePropertyCmd)
 	assignCmd.AddCommand(assignPropertyCmd)
+	unassignCmd.AddCommand(unassignPropertyCmd)
 
 	// Property Definition Commands
 	exampleCmd.AddCommand(examplePropertyDefinitionCmd)

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/creasty/defaults v1.7.0
 	github.com/go-git/go-git/v5 v5.11.0
-	github.com/go-resty/resty/v2 v2.10.0
+	github.com/go-resty/resty/v2 v2.11.0
 	github.com/gosimple/slug v1.13.1
 	github.com/itchyny/gojq v0.12.14
 	github.com/manifoldco/promptui v0.9.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -159,8 +159,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.16.0 h1:x+plE831WK4vaKHO/jpgUGsvLKIqRRkz6M78GuJAfGE=
 github.com/go-playground/validator/v10 v10.16.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
-github.com/go-resty/resty/v2 v2.10.0 h1:Qla4W/+TMmv0fOeeRqzEpXPLfTUnR5HZ1+lGs+CkiCo=
-github.com/go-resty/resty/v2 v2.10.0/go.mod h1:iiP/OpA0CkcL3IGt1O0+/SIItFUbkkyw5BGXiVdTu+A=
+github.com/go-resty/resty/v2 v2.11.0 h1:i7jMfNOJYMp69lq7qozJP+bjgzfAzeOhuGlyDrqxT/8=
+github.com/go-resty/resty/v2 v2.11.0/go.mod h1:iiP/OpA0CkcL3IGt1O0+/SIItFUbkkyw5BGXiVdTu+A=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=


### PR DESCRIPTION
## Issues

[#10](https://github.com/OpsLevel/product/issues/10)

## Changelog

Added `assign` and `unassign` commands.

Add `PropertyInput` to example commands so 

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```bash
opslevel example property > my-prop.yaml
# update my-prop.yaml with owner and (property) definition identifiers

opslevel assign property -f my-prop.yaml

# "owner-alias" and "property-id" derived from "my-prop.yaml"
opslevel get property owner-alias property-id

opslevel unassign property owner-alias property-id
```
