### PR TITLE
Add support for listing properties assigned on a service

### DIFF
--- a/.changes/unreleased/Feature-20231227-145903.yaml
+++ b/.changes/unreleased/Feature-20231227-145903.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add support for listing Properties on a Service
+time: 2023-12-27T14:59:03.118701-05:00


### PR DESCRIPTION
## Issues

As part of https://github.com/OpsLevel/product/issues/10

## Changelog

- [x] Add `opslevel list property`

## Tophatting

```
~/repos/cli/src ta/list-service-props ❯ o list property computer                                                                                   Ruby 3.0.0 02:23:14 PM
DEFINITION_ID                                            VALUE                                                                                                                       LEN_VALIDATION_ERRORS  
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xODA  "blue"                                                                                                                      0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xODI                                                                                                                              0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi85OA                                                                                                                               0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi82OA                                                                                                                               0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi82OQ                                                                                                                               0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xODY  {"maintainer":"platform","git_repository":{"host":"gitlab","path":"opslevel/opslevel-terraform"},"terraform_managed":true}  0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xNTU                                                                                                                              0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xNTc                                                                                                                              0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xMTQ                                                                                                                              0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xNDI                                                                                                                              0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xNTM                                                                                                                              0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi82NQ                                                                                                                               0
Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi82Ng                                                                                                                               0
```
