### PR TITLE
CLI - allow unsetting optional references (IdentifierInput changes)

### DIFF
--- a/.changes/unreleased/Bugfix-20231229-130258.yaml
+++ b/.changes/unreleased/Bugfix-20231229-130258.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bugs where unset ID/IdentifierInput fields were not being omitted on update
+time: 2023-12-29T13:02:58.119377-05:00

--- a/.changes/unreleased/Bugfix-20231229-130331.yaml
+++ b/.changes/unreleased/Bugfix-20231229-130331.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bugs where optional ID/IdentifierInput fields were not being unset on update
+time: 2023-12-29T13:03:31.586713-05:00

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ src/dist
 .DS_Store
 go.work*
 **coverage.txt
+src/*.yaml
+

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -75,7 +75,7 @@ var getActionCmd = &cobra.Command{
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		action, err := getClientGQL().GetCustomAction(*opslevel.NewIdentifier(key))
+		action, err := getClientGQL().GetCustomAction(key)
 		cobra.CheckErr(err)
 		common.PrettyPrint(action)
 	},
@@ -141,7 +141,7 @@ var deleteActionCmd = &cobra.Command{
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		err := getClientGQL().DeleteWebhookAction(*opslevel.NewIdentifier(key))
+		err := getClientGQL().DeleteWebhookAction(key)
 		cobra.CheckErr(err)
 		fmt.Printf("deleted webhook action: %s\n", key)
 	},

--- a/src/cmd/trigger_definition.go
+++ b/src/cmd/trigger_definition.go
@@ -69,7 +69,7 @@ var getTriggerDefinitionCmd = &cobra.Command{
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		triggerDefinition, err := getClientGQL().GetTriggerDefinition(*opslevel.NewIdentifier(key))
+		triggerDefinition, err := getClientGQL().GetTriggerDefinition(key)
 		cobra.CheckErr(err)
 		common.PrettyPrint(triggerDefinition)
 	},
@@ -129,7 +129,7 @@ var deleteTriggerDefinitionCmd = &cobra.Command{
 	ArgAliases: []string{"ID", "ALIAS"},
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
-		err := getClientGQL().DeleteTriggerDefinition(*opslevel.NewIdentifier(key))
+		err := getClientGQL().DeleteTriggerDefinition(key)
 		cobra.CheckErr(err)
 		fmt.Printf("deleted trigger definition: %s\n", key)
 	},


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/opslevel-go/pull/343

https://github.com/OpsLevel/team-platform/issues/158

## Changelog

- [x] No need to use `IdentifierInput` to do client queries
- [x] Thanks to opslevel-go changes to add yaml tags, `*ID` and `*IdentifierInput` fields are truly optional\*
- [x] Make a `changie` entry

\*Can unset an optional ID by using `id: ""`, can unset an optional IdentifierInput by using

```
identifierField:
    id: null
    alias: null
```

## Tophatting

### Examples still work

```
$ o example service
name: Hello World
product: OSS
description: Hello World Service
language: Go
framework: fasthttp
tierAlias: tier_4
ownerInput:
    alias: Platform
lifecycleAlias: beta
parent:
    alias: Engineering

```

### Test unsetting owner

Create the service with owner

```
$ cat create.yaml
name: SVC from CLI
product: OSS
description: Hello World Service
language: Go
framework: fasthttp
tierAlias: tier_4
ownerInput:
    alias: platform
lifecycleAlias: beta
$ o create service -f create.yaml
"Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MjYwMw"
```

Change some property, owner should be unchanged

```
$ cat update_description.yaml
alias: svc_from_cli
description: owner has been removed
$ o update service -f update_description.yaml
...
    "name": "SVC from CLI",
    "owner": {
        "Alias": "platform",
        "Id": "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
    },
    "product": "OSS",
...
```

Remove the owner

```
$ cat remove_owner.yaml
alias: svc_from_cli
ownerInput:
    id: null
    alias: null
$ o update service -f remove_owner.yaml
...
    "name": "SVC from CLI",
    "owner": {
        "Alias": "",
        "Id": null
    },
    "product": "OSS",
...
```