### PR TITLE
Prevent harmful usage of `defaults.Set()`

### DIFF
--- a/.changes/unreleased/Bugfix-20240105-154208.yaml
+++ b/.changes/unreleased/Bugfix-20240105-154208.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug in Infra where unexpected data would be included in requests
+time: 2024-01-05T15:42:08.827698-05:00

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/opslevel/opslevel-go/v2023"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -466,8 +465,5 @@ func readCheckInput() (*CheckInputType, error) {
 	// Unmarshall
 	evt := &CheckInputType{}
 	viper.Unmarshal(&evt)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
 	return evt, nil
 }

--- a/src/cmd/infra.go
+++ b/src/cmd/infra.go
@@ -249,8 +249,11 @@ func readInfraInput() (*opslevel.InfraInput, error) {
 	cobra.CheckErr(err)
 	evt := &opslevel.InfraInput{}
 	cobra.CheckErr(yaml.Unmarshal(file, &evt))
+	log.Info().Msgf("before %s %s %+v +%v\n", evt.Schema, *evt.Owner, evt.Provider, evt.Data)
 	if err := defaults.Set(evt); err != nil {
 		return nil, err
 	}
+	log.Info().Msgf("after %s %s %+v +%v\n", evt.Schema, *evt.Owner, evt.Provider, evt.Data)
+	panic("bye")
 	return evt, nil
 }

--- a/src/cmd/infra.go
+++ b/src/cmd/infra.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/creasty/defaults"
 	"github.com/opslevel/cli/common"
 	"github.com/opslevel/opslevel-go/v2023"
 	"github.com/rs/zerolog/log"
@@ -249,11 +248,5 @@ func readInfraInput() (*opslevel.InfraInput, error) {
 	cobra.CheckErr(err)
 	evt := &opslevel.InfraInput{}
 	cobra.CheckErr(yaml.Unmarshal(file, &evt))
-	log.Info().Msgf("before %s %s %+v +%v\n", evt.Schema, *evt.Owner, evt.Provider, evt.Data)
-	if err := defaults.Set(evt); err != nil {
-		return nil, err
-	}
-	log.Info().Msgf("after %s %s %+v +%v\n", evt.Schema, *evt.Owner, evt.Provider, evt.Data)
-	panic("bye")
 	return evt, nil
 }


### PR DESCRIPTION
## Issues

The [defaults package](https://pkg.go.dev/github.com/creasty/defaults#section-readme) is used in CLI and it will set everything that is not populated in a struct to what's in the `default` tag. Currently in opslevel-go the `default` tag is set to so we can show examples, but we should probably use something else. CLI is affected because we have `defaults.Set()` calls.

Affected parts of CLI:

1. [CheckInput](https://github.com/OpsLevel/cli/blob/f66d7ccccfcef56c7a4fcdec7b7a4d969a911950/src/cmd/check.go#L447-L451) - not a problem since there's no `default` tags and the struct is defined in CLI (for some reason.)
2. [DeployEvent](https://github.com/OpsLevel/cli/blob/f66d7ccccfcef56c7a4fcdec7b7a4d969a911950/src/cmd/deploy.go#L38-L48) - not a problem since there's only one `default` tag and it's useful and the struct is defined in CLI (for some reason.)
3. [InfraInput](https://github.com/OpsLevel/cli/blob/f66d7ccccfcef56c7a4fcdec7b7a4d969a911950/src/cmd/infra.go#L252-L254) - actually harmful, since example data gets sent to the server without the user having a clue

## Changelog

- [x] Remove unncessary call in CheckInput - doesn't do anything
- [x] Remove harmful in InfraInput - see tophatting
- [x] Make a `changie` entry

## Tophatting

Before:

```
~/repos/cli/src main !2 ❯ cat << EOF | o create infra -f -                                                                                                                              х INT Ruby 3.0.0 03:24:27 PM
owner: "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
provider:
  account: "Dev - 123456789"
  name: "GCP"
  type: "BigQuery"
  url: "https://google.com"
EOF
3:24PM INF before  Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5 &{Account:Dev - 123456789 Name:GCP Type:BigQuery URL:https://google.com} +map[]

3:24PM INF after Database Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5 &{Account:Dev - 123456789 Name:GCP Type:BigQuery URL:https://google.com} +map[endpoint:https://google.com engine:BigQuery name:my-big-query replica:false]

panic: bye
```

After:

InfraInput will just get an API error as expected since a required field is not set.