### PR TITLE
Small fixes | Cut down on number of `TODO` comments

### DIFF
--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/opslevel/opslevel-go/v2024"
@@ -55,7 +56,7 @@ opslevel delete alias -t infrastructure-resource my-infra-alias`,
 	Run: func(cmd *cobra.Command, args []string) {
 		alias := args[0]
 		aliasType := cmd.Flags().Lookup("type").Value.String()
-		if !Contains(opslevel.AllAliasOwnerTypeEnum, aliasType) {
+		if !slices.Contains(opslevel.AllAliasOwnerTypeEnum, aliasType) {
 			log.Error().Msgf("invalid alias type '%s'", aliasType)
 			os.Exit(1)
 		}

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opslevel/cli/common"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // Commands
@@ -439,12 +438,8 @@ func marshalCheck(check opslevel.Check) *CheckInputType {
 
 var CheckConfigCurrentVersion = "1"
 
-type ConfigVersion struct {
-	Version string
-}
-
 type CheckInputType struct {
-	Version string
+	Version string `yaml:"Version"`
 	Kind    opslevel.CheckType
 	Spec    map[string]interface{}
 }
@@ -455,15 +450,14 @@ func (self *CheckInputType) IsUpdateInput() bool {
 }
 
 func readCheckInput() (*CheckInputType, error) {
-	readInputConfig()
-	// Validate Version
-	v := &ConfigVersion{}
-	viper.Unmarshal(&v)
-	if v.Version != CheckConfigCurrentVersion {
-		return nil, fmt.Errorf("Supported config version is '%s' but found '%s' | Please update config file", CheckConfigCurrentVersion, v.Version)
+	input, err := readResourceInput[CheckInputType]()
+	fmt.Println(input)
+	if err != nil {
+		return nil, err
 	}
-	// Unmarshall
-	evt := &CheckInputType{}
-	viper.Unmarshal(&evt)
-	return evt, nil
+	if input.Version != CheckConfigCurrentVersion {
+		return nil, fmt.Errorf("supported config version is '%s' but found '%s' | please update config file",
+			CheckConfigCurrentVersion, input.Version)
+	}
+	return input, nil
 }

--- a/src/cmd/input.go
+++ b/src/cmd/input.go
@@ -12,15 +12,15 @@ import (
 
 var dataFile string
 
+// TODO: deploy.go is still relying on this because it uses viper to bind config
+// we need to stop using viper in such a way and just rely on readResourceInput
 func readInputConfig() {
 	viper.SetConfigType("yaml")
 	switch dataFile {
 	case ".":
-		// TODO: does this block ever actually ever run?
 		viper.SetConfigFile("./data.yaml")
 	case "-":
 		if isStdInFromTerminal() {
-			// TODO: this can take up to half a second to output which interrupts the user's experience
 			log.Info().Msg("Reading input directly from command line... Press CTRL+D to stop typing")
 		}
 		viper.ReadConfig(os.Stdin)

--- a/src/cmd/system.go
+++ b/src/cmd/system.go
@@ -31,7 +31,7 @@ var createSystemCmd = &cobra.Command{
 		cat << EOF | opslevel create system -f -
 		name: "My System"
 		description: "Hello World System"
-		owner: "Z2lkOi8vb3BzbGV2ZWwvVGVhbS83NjY"
+		ownerId: "Z2lkOi8vb3BzbGV2ZWwvVGVhbS83NjY"
 		parent:
 			alias: "alias of domain"
 		note: "Additional system details"
@@ -97,7 +97,6 @@ var listSystemCmd = &cobra.Command{
 	},
 }
 
-// TODO: bug in API prevents use of alias in this function.  Adding full functionality for now.
 var updateSystemCmd = &cobra.Command{
 	Use:     "system ID|ALIAS",
 	Aliases: []string{"sys"},
@@ -107,7 +106,7 @@ var updateSystemCmd = &cobra.Command{
 		cat << EOF | opslevel update system my-system-alias-or-id -f -
 		name: "My Updated System"
 		description: "Hello Updated System"
-		owner: "Z2lkOi8vb3BzbGV2ZWwvVGVhbS83NjY"
+		ownerId: "Z2lkOi8vb3BzbGV2ZWwvVGVhbS83NjY"
 		parent:
 			alias: "my_domain"
 		note: "Additional system details for my updated system"

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -38,7 +39,7 @@ opslevel create user "jane@example.com" "Jane Doe" Admin --skip-welcome-email
 		role := opslevel.UserRoleUser
 		if len(args) > 2 {
 			desiredRole := strings.ToLower(args[2])
-			if Contains(opslevel.AllUserRole, desiredRole) {
+			if slices.Contains(opslevel.AllUserRole, desiredRole) {
 				role = opslevel.UserRole(desiredRole)
 			}
 		}
@@ -139,16 +140,6 @@ var deleteUserCmd = &cobra.Command{
 	},
 }
 
-// TODO: move this to opslevel_common
-func Contains[T comparable](s []T, e T) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
-}
-
 var importUsersCmd = &cobra.Command{
 	Use:     "user",
 	Aliases: []string{"users"},
@@ -175,7 +166,7 @@ EOF
 				continue
 			}
 			userRole := opslevel.UserRoleUser
-			if Contains(opslevel.AllUserRole, role) {
+			if slices.Contains(opslevel.AllUserRole, role) {
 				userRole = opslevel.UserRole(role)
 			}
 			input := opslevel.UserInput{


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/154 - reduce usage of readInputConfig

Basically I went through all the review comments in `src/cmd/*.go` and `src/common/*.go` to see what could be fixed easily. Found that deploys needs more attention [so I made a ticket for that.](https://github.com/OpsLevel/team-platform/issues/196)

## Changelog

- [x] Remove our own `slice.Contains` function in common - Go provides this now.
- [x] Remove a comment explaining that system can't use alias - this is not true I tested it.
- [x] Checks - stop using `readInputConfig` - tested below.
- [ ] ~~Make a `changie` entry~~ Not needed

## Tophatting

<details>

```
$ cat sys-update.yaml
name: update 2 lol
description: AAAAAAAAAAAAA
owner: Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5
$ go run main.go update system taimoor_s_orange_system -f sys-update.yaml
Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc4OTg3Mw
$ opslevel get system taimoor_s_orange_system
  "Name": "update 2 lol",
  "Description": "AAAAAAAAAAAAA",
  "HTMLUrl": "https://app.opslevel.com/catalog/systems/update_2_lol",
  "Owner": {
    "OnTeam": {
      "alias": "platform",
      "id": "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
    }
  },
```

```
$ cat check-create-repo-grep.yaml
Version: 1
kind: repo_grep
spec:
  name: CLI repo grep check
  enabled: false
  category: quality
  level: ultimate
  owner: platform
  filePaths:
  - Taskfile.yml
  fileContentsPredicate:
    type: contains
    value: CLI
$ go run main.go create check -f check-create-repo-grep.yaml --noninteractive
5:06PM WRN no value supplied for field 'filter'
Created Check 'CLI repo grep check' with id 'Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yMDU1OQ'
$ cat check-create-repo-grep.yaml
Version: 1
kind: repo_grep
spec:
  name: CLI repo grep check
  enabled: false
  category: quality
  level: ultimate
  owner: platform
  filePaths:
  - Taskfile.yml
  fileContentsPredicate:
    type: contains
    value: CLI
```

</details>