### PR TITLE
Use ubuntu noble provided `jq` version 1.7.1 in Dockerfile

### DIFF
--- a/.changes/unreleased/Bugfix-20240123-093822.yaml
+++ b/.changes/unreleased/Bugfix-20240123-093822.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Dockerfile now uses Ubuntu provided jq package
+time: 2024-01-23T09:38:22.042364-05:00

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ### Prerequisite
 
-- [jq](https://stedolan.github.io/jq/download/)
+- [jq version 1.7](https://stedolan.github.io/jq/download/)
 - [OpsLevel API Token](https://app.opslevel.com/api_tokens)
   - Generate token by clicking `Create API Token` and providing a description
   - Export the API Token for cli access:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,8 +3,6 @@ ENV USER_UID=1001 USER_NAME=opslevel
 ENTRYPOINT ["/usr/local/bin/opslevel"]
 WORKDIR /app
 RUN apt-get update && \
-    apt-get install -y curl && \
-    apt-get purge && apt-get clean && apt-get autoclean && \
-    curl -o /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq && \
-    chmod +x /usr/local/bin/jq
+    apt-get install -y curl jq && \
+    apt-get purge && apt-get clean && apt-get autoclean
 COPY opslevel /usr/local/bin

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:focal AS release
+FROM ubuntu:noble AS release
 ENV USER_UID=1001 USER_NAME=opslevel
 ENTRYPOINT ["/usr/local/bin/opslevel"]
 WORKDIR /app
 RUN apt-get update && \
-    apt-get install -y curl jq && \
+    apt-get install -y jq && \
     apt-get purge && apt-get clean && apt-get autoclean
 COPY opslevel /usr/local/bin


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/200

## Changelog

- [x] Update dockerfile to use ubuntu provided `jq` to replace unsecure HTTP link.
- [x] Changed Ubuntu image to `noble` so that we can get version 1.7 rather than 1.6
- [x] Make a `changie` entry

## Tophatting

```
$ GOOS=linux GOARCH=arm64 go build -o opslevel .
```

<img width="1019" alt="image" src="https://github.com/OpsLevel/cli/assets/37668804/22df69a5-0ce3-40f0-b293-165a8eea168e">
