### PR TITLE
Db/update version output

### DIFF
--- a/.changes/unreleased/Feature-20240131-091635.yaml
+++ b/.changes/unreleased/Feature-20240131-091635.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add --short flag to version command
+time: 2024-01-31T09:16:35.740603-06:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,12 +59,12 @@ tasks:
       - go get -u "{{.OPSLEVEL_GO_PKG}}"
 
   workspace:
-    desc: Setup workspace for cli & opslevel-go development
+    desc: Setup local workspace for cli & opslevel-go development
     dir: "{{.SRC_DIR}}"
     cmds:
       - cmd: echo "Setting up opslevel-go workspace..."
         silent: true
-      - git submodule update --init --remote
+      - git -C .. submodule update --init --remote
       - go work init || true
       - go work use . submodules/opslevel-go
       - cmd: echo "opslevel-go workspace ready!"

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -28,9 +28,10 @@ type GoInfo struct {
 }
 
 var (
-	version = "development"
-	commit  = "none"
-	build   Build
+	shortVersionFlag bool
+	version          = "development"
+	commit           = "none"
+	build            Build
 )
 
 func initBuild() {
@@ -75,9 +76,14 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	versionCmd.PersistentFlags().BoolVar(&shortVersionFlag, "short", false, "Print only version number")
 }
 
 func runVersion(cmd *cobra.Command, args []string) error {
+	if shortVersionFlag {
+		fmt.Printf("%s-%s\n", version, commit)
+		return nil
+	}
 	initBuild()
 	versionInfo, err := json.MarshalIndent(build, "", "    ")
 	if err != nil {


### PR DESCRIPTION
## Issues

[#213](https://github.com/OpsLevel/team-platform/issues/213)

## Changelog

Add `--short` flag to version command

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`opslevel version --short` outputs <version>-<commit-hash>
