### PR TITLE
fix bug in list services maturity cmd

### DIFF
--- a/src/cmd/maturity.go
+++ b/src/cmd/maturity.go
@@ -30,7 +30,8 @@ There are multiple output formats that are useful
 		categoriesConn, err := client.ListCategories(nil)
 		cobra.CheckErr(err)
 		categories := categoriesConn.Nodes
-		data, err := client.ListServicesMaturity()
+		response, err := client.ListServicesMaturity(nil)
+		data := response.Nodes
 		cobra.CheckErr(err)
 		headers := []string{"Name", "Overall"}
 		sort.Slice(categories, func(i, j int) bool {

--- a/src/cmd/maturity.go
+++ b/src/cmd/maturity.go
@@ -31,8 +31,8 @@ There are multiple output formats that are useful
 		cobra.CheckErr(err)
 		categories := categoriesConn.Nodes
 		response, err := client.ListServicesMaturity(nil)
-		data := response.Nodes
 		cobra.CheckErr(err)
+		data := response.Nodes
 		headers := []string{"Name", "Overall"}
 		sort.Slice(categories, func(i, j int) bool {
 			return categories[i].Name < categories[j].Name


### PR DESCRIPTION
## Issues

[263](https://github.com/OpsLevel/team-platform/issues/263)

## Changelog

Minor bugfix. Depends on [upstream opslevel-go fixes](https://github.com/OpsLevel/opslevel-go/pull/381)

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

```bash
# In orange acct, where we have over 100 services
opslevel list services maturity -o csv > service_maturity.csv
```