### PR TITLE
Instantiate the opslevel-go cache, set logger for that cache

### DIFF
--- a/.changes/unreleased/Bugfix-20240309-180022.yaml
+++ b/.changes/unreleased/Bugfix-20240309-180022.yaml
@@ -1,3 +1,3 @@
 kind: Bugfix
-body: ALlow setting log level to trace, log level now affects cache logs
+body: Allow setting log level to trace, log level now affects cache logs
 time: 2024-03-09T18:00:22.986942-05:00

--- a/.changes/unreleased/Bugfix-20240309-180022.yaml
+++ b/.changes/unreleased/Bugfix-20240309-180022.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: ALlow setting log level to trace, log level now affects cache logs
+time: 2024-03-09T18:00:22.986942-05:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,6 @@ tasks:
     dir: "{{.SRC_DIR}}"
     cmds:
       - test -z "$(gofumpt -d -e . | tee /dev/stderr)"
-      - go vet ./...
       - golangci-lint run
 
   fix:

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -152,11 +152,12 @@ func createCheck(input CheckInputType, usePrompts bool) (*opslevel.Check, error)
 	var output *opslevel.Check
 	var err error
 	clientGQL := getClientGQL()
-	opslevel.Cache.CacheCategories(clientGQL)
-	opslevel.Cache.CacheLevels(clientGQL)
-	opslevel.Cache.CacheTeams(clientGQL)
-	opslevel.Cache.CacheFilters(clientGQL)
-	opslevel.Cache.CacheIntegrations(clientGQL)
+	cacher := getCacher()
+	cacher.CacheCategories(clientGQL)
+	cacher.CacheLevels(clientGQL)
+	cacher.CacheTeams(clientGQL)
+	cacher.CacheFilters(clientGQL)
+	cacher.CacheIntegrations(clientGQL)
 	err = input.resolveCategoryAliases(clientGQL, usePrompts)
 	cobra.CheckErr(err)
 	err = input.resolveLevelAliases(clientGQL, usePrompts)
@@ -184,11 +185,12 @@ func updateCheck(input CheckInputType, usePrompts bool) (*opslevel.Check, error)
 	var output *opslevel.Check
 	var err error
 	clientGQL := getClientGQL()
-	opslevel.Cache.CacheCategories(clientGQL)
-	opslevel.Cache.CacheLevels(clientGQL)
-	opslevel.Cache.CacheTeams(clientGQL)
-	opslevel.Cache.CacheFilters(clientGQL)
-	opslevel.Cache.CacheIntegrations(clientGQL)
+	cacher := getCacher()
+	cacher.CacheCategories(clientGQL)
+	cacher.CacheLevels(clientGQL)
+	cacher.CacheTeams(clientGQL)
+	cacher.CacheFilters(clientGQL)
+	cacher.CacheIntegrations(clientGQL)
 	err = input.resolveCategoryAliases(clientGQL, usePrompts)
 	cobra.CheckErr(err)
 	err = input.resolveLevelAliases(clientGQL, usePrompts)
@@ -217,7 +219,7 @@ func updateCheck(input CheckInputType, usePrompts bool) (*opslevel.Check, error)
 func (checkInputType *CheckInputType) resolveCategoryAliases(client *opslevel.Client, usePrompt bool) error {
 	if item, ok := checkInputType.Spec["category"]; ok {
 		delete(checkInputType.Spec, "category")
-		if value, ok := opslevel.Cache.TryGetCategory(item.(string)); ok {
+		if value, ok := getCacher().TryGetCategory(item.(string)); ok {
 			checkInputType.Spec["categoryId"] = value.Id
 			return nil
 		} else {
@@ -243,7 +245,7 @@ func (checkInputType *CheckInputType) resolveCategoryAliases(client *opslevel.Cl
 func (checkInputType *CheckInputType) resolveLevelAliases(client *opslevel.Client, usePrompt bool) error {
 	if item, ok := checkInputType.Spec["level"]; ok {
 		delete(checkInputType.Spec, "level")
-		if value, ok := opslevel.Cache.TryGetLevel(item.(string)); ok {
+		if value, ok := getCacher().TryGetLevel(item.(string)); ok {
 			checkInputType.Spec["levelId"] = value.Id
 			return nil
 		} else {
@@ -269,7 +271,7 @@ func (checkInputType *CheckInputType) resolveLevelAliases(client *opslevel.Clien
 func (checkInputType *CheckInputType) resolveTeamAliases(client *opslevel.Client, usePrompt bool) error {
 	if item, ok := checkInputType.Spec["owner"]; ok {
 		delete(checkInputType.Spec, "owner")
-		if value, ok := opslevel.Cache.TryGetTeam(item.(string)); ok {
+		if value, ok := getCacher().TryGetTeam(item.(string)); ok {
 			checkInputType.Spec["ownerId"] = value.Id
 			return nil
 		} else {
@@ -293,7 +295,7 @@ func (checkInputType *CheckInputType) resolveTeamAliases(client *opslevel.Client
 func (checkInputType *CheckInputType) resolveFilterAliases(client *opslevel.Client, usePrompt bool) error {
 	if item, ok := checkInputType.Spec["filter"]; ok {
 		delete(checkInputType.Spec, "filter")
-		if value, ok := opslevel.Cache.TryGetFilter(item.(string)); ok {
+		if value, ok := getCacher().TryGetFilter(item.(string)); ok {
 			checkInputType.Spec["filterId"] = value.Id
 			return nil
 		} else {
@@ -317,7 +319,7 @@ func (checkInputType *CheckInputType) resolveFilterAliases(client *opslevel.Clie
 func (checkInputType *CheckInputType) resolveIntegrationAliases(client *opslevel.Client, usePrompt bool) error {
 	if item, ok := checkInputType.Spec["integration"]; ok {
 		delete(checkInputType.Spec, "integration")
-		if value, ok := opslevel.Cache.TryGetIntegration(item.(string)); ok {
+		if value, ok := getCacher().TryGetIntegration(item.(string)); ok {
 			checkInputType.Spec["integrationId"] = value.Id
 			return nil
 		} else {

--- a/src/cmd/infra.go
+++ b/src/cmd/infra.go
@@ -69,8 +69,8 @@ opslevel --log-level=ERROR get infra-schema Compute > ~/.opslevel/schemas/comput
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
 		client := getClientGQL()
-		opslevel.Cache.CacheInfraSchemas(client)
-		schema, found := opslevel.Cache.TryGetInfrastructureSchema(key)
+		getCacher().CacheInfraSchemas(client)
+		schema, found := getCacher().TryGetInfrastructureSchema(key)
 		if !found {
 			log.Error().Msgf("unable to find infrastructure schema '%s'", key)
 			return

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -68,14 +68,14 @@ func setupLogging() {
 		log.Logger = log.Output(output)
 	}
 
-	switch {
-	case logLevel == "error":
+	switch logLevel {
+	case "error":
 		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
-	case logLevel == "warn":
+	case "warn":
 		zerolog.SetGlobalLevel(zerolog.WarnLevel)
-	case logLevel == "debug":
+	case "debug":
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	case logLevel == "trace":
+	case "trace":
 		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	default:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -18,6 +18,7 @@ import (
 var (
 	_clientRest *resty.Client
 	_clientGQL  *opslevel.Client
+	_cacher     *opslevel.Cacher
 )
 
 var rootCmd = &cobra.Command{
@@ -74,6 +75,8 @@ func setupLogging() {
 		zerolog.SetGlobalLevel(zerolog.WarnLevel)
 	case logLevel == "debug":
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	case logLevel == "trace":
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	default:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
@@ -91,4 +94,12 @@ func getClientGQL(options ...opslevel.Option) *opslevel.Client {
 		_clientGQL = common.NewGraphClient(version, options...)
 	}
 	return _clientGQL
+}
+
+func getCacher() *opslevel.Cacher {
+	if _cacher == nil {
+		logger := log.With().Str("from", "opslevel-go-cacher").Logger()
+		_cacher = opslevel.NewCacher(&logger)
+	}
+	return _cacher
 }

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -160,9 +160,9 @@ EOF
 	Run: func(cmd *cobra.Command, args []string) {
 		reader, err := readImportFilepathAsCSV()
 		client := getClientGQL()
-		opslevel.Cache.CacheLifecycles(client)
-		opslevel.Cache.CacheTiers(client)
-		opslevel.Cache.CacheTeams(client)
+		getCacher().CacheLifecycles(client)
+		getCacher().CacheTiers(client)
+		getCacher().CacheTeams(client)
 		cobra.CheckErr(err)
 		for reader.Rows() {
 			name := reader.Text("Name")
@@ -175,19 +175,19 @@ EOF
 			}
 			tier := reader.Text("Tier")
 			if tier != "" {
-				if item, ok := opslevel.Cache.Tiers[tier]; ok {
+				if item, ok := getCacher().Tiers[tier]; ok {
 					input.TierAlias = &item.Alias
 				}
 			}
 			lifecycle := reader.Text("Lifecycle")
 			if lifecycle != "" {
-				if item, ok := opslevel.Cache.Lifecycles[lifecycle]; ok {
+				if item, ok := getCacher().Lifecycles[lifecycle]; ok {
 					input.LifecycleAlias = &item.Alias
 				}
 			}
 			owner := reader.Text("Owner")
 			if owner != "" {
-				if item, ok := opslevel.Cache.Teams[owner]; ok {
+				if item, ok := getCacher().Teams[owner]; ok {
 					input.OwnerInput = opslevel.NewIdentifier(item.Alias)
 				}
 			}


### PR DESCRIPTION
## Issues

Relies on: https://github.com/OpsLevel/opslevel-go/pull/383

Issue: https://github.com/OpsLevel/team-platform/issues/214

## Changelog

- [x] Allow trace level logging
- [x] Instantiate the opslevel-go cache the same way the API client is instantiated
- [x] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
