### PR TITLE
add "--hidden" flag to list respositories command

### DIFF
--- a/.changes/unreleased/Feature-20240426-095741.yaml
+++ b/.changes/unreleased/Feature-20240426-095741.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: add "--hidden" flag to list respositories command
+body: add "--hidden-only" flag to list respositories command
 time: 2024-04-26T09:57:41.52076-05:00

--- a/.changes/unreleased/Feature-20240426-095741.yaml
+++ b/.changes/unreleased/Feature-20240426-095741.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add "--hidden" flag to list respositories command
+time: 2024-04-26T09:57:41.52076-05:00

--- a/src/cmd/repository.go
+++ b/src/cmd/repository.go
@@ -42,8 +42,11 @@ var listRepositoryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClientGQL()
 		payloadVars := client.InitialPageVariables()
-		// The --hidden flag lists only hidden repos
-		payloadVars["visible"] = !cmd.Flag("hidden").Changed
+
+		hiddenOnly, err := cmd.Flags().GetBool("hidden-only")
+		cobra.CheckErr(err)
+		// visible set to false means "hidden" in the API
+		payloadVars["visible"] = !hiddenOnly
 
 		resp, err := client.ListRepositories(&payloadVars)
 		list := resp.Nodes
@@ -62,6 +65,6 @@ var listRepositoryCmd = &cobra.Command{
 
 func init() {
 	getCmd.AddCommand(getRepositoryCmd)
-	listRepositoryCmd.Flags().Bool("hidden", false, "list only hidden repositories when set")
+	listRepositoryCmd.Flags().Bool("hidden-only", false, "list only hidden repositories when set")
 	listCmd.AddCommand(listRepositoryCmd)
 }

--- a/src/cmd/repository.go
+++ b/src/cmd/repository.go
@@ -38,8 +38,14 @@ var listRepositoryCmd = &cobra.Command{
 	Aliases: []string{"repositories", "repo", "repos"},
 	Short:   "Lists repositories",
 	Long:    `Lists repositories`,
+	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		resp, err := getClientGQL().ListRepositories(nil)
+		client := getClientGQL()
+		payloadVars := client.InitialPageVariables()
+		// The --hidden flag lists only hidden repos
+		payloadVars["visible"] = !cmd.Flag("hidden").Changed
+
+		resp, err := client.ListRepositories(&payloadVars)
 		list := resp.Nodes
 		cobra.CheckErr(err)
 		if isJsonOutput() {
@@ -56,5 +62,6 @@ var listRepositoryCmd = &cobra.Command{
 
 func init() {
 	getCmd.AddCommand(getRepositoryCmd)
+	listRepositoryCmd.Flags().Bool("hidden", false, "list only hidden repositories when set")
 	listCmd.AddCommand(listRepositoryCmd)
 }


### PR DESCRIPTION
## Issues

[CLI feature - ability to get list of hidden repositories](https://github.com/OpsLevel/team-platform/issues/226)

Dependent on [upstream opslevel-go PR](https://github.com/OpsLevel/opslevel-go/pull/392)

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```bash
# in orange
opslevel list repos --hidden | wc -l
    27
opslevel list repos | wc -l
    2227
```