### PR TITLE
bugfix - support all environment variables when using `opslevel create deploy`

### DIFF
--- a/.changes/unreleased/Bugfix-20240523-114929.yaml
+++ b/.changes/unreleased/Bugfix-20240523-114929.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Support all CLI options for `opslevel create deploy` as env vars (OL_ENVIRONMENT,
+  OL_DESCRIPTION, OL_SERVICE)
+time: 2024-05-23T11:49:29.694134-04:00

--- a/.changes/unreleased/Bugfix-20240523-114929.yaml
+++ b/.changes/unreleased/Bugfix-20240523-114929.yaml
@@ -1,4 +1,4 @@
 kind: Bugfix
 body: Support all CLI options for `opslevel create deploy` as env vars (OL_ENVIRONMENT,
-  OL_DESCRIPTION, OL_SERVICE)
+  OL_DESCRIPTION, OL_SERVICE, OL_INTEGRATION_URL)
 time: 2024-05-23T11:49:29.694134-04:00

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -49,8 +49,8 @@ type DeployEvent struct {
 
 var deployCreateCmd = &cobra.Command{
 	Use:   "deploy",
-	Short: "Create deployment events (report deploy)",
-	Long:  "Create deployment events (report deploy)",
+	Short: "Create deployment events",
+	Long:  "Create deployment events (report a deployment to OpsLevel using an integration url)",
 	Run: func(cmd *cobra.Command, args []string) {
 		if integrationUrl == "" {
 			log.Error().Msg("Please provide '--integration-url' to send the deployment information to")

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -86,33 +86,46 @@ var deployCreateCmd = &cobra.Command{
 func init() {
 	createCmd.AddCommand(deployCreateCmd)
 
-	deployCreateCmd.Flags().StringVarP(&integrationUrl, "integration-url", "i", "", "OpsLevel integration url (OPSLEVEL_INTEGRATION_URL)")
 	deployCreateCmd.Flags().Bool("dry-run", false, "if true data will be logged and not sent to the integration-url (OPSLEVEL_DRY_RUN)")
-	deployCreateCmd.Flags().String("git-path", "./", "relative path to grab the git commit info from (if git repo is found overrides all commit details)")
+	viper.BindEnv("dry-run", "OPSLEVEL_DRY_RUN", "OL_DRY_RUN")
 
-	deployCreateCmd.Flags().StringP("service", "s", "", "service alias for the event (OPSLEVEL_SERVICE)")
-	deployCreateCmd.Flags().StringP("description", "d", "", "description of the event (OPSLEVEL_DESCRIPTION)")
-	deployCreateCmd.Flags().StringP("environment", "", "", "environment name of the event (OPSLEVEL_ENVIRONMENT)")
-	deployCreateCmd.Flags().StringP("deploy-number", "", "", "deploy number of the event (OPSLEVEL_DEPLOY_NUMBER)")
-	deployCreateCmd.Flags().String("deploy-url", "", "url the event will link back to (OPSLEVEL_DEPLOY_URL)")
-	deployCreateCmd.Flags().String("dedup-id", "", "dedup id of the event (OPSLEVEL_DEDUP_ID)")
-
-	deployCreateCmd.Flags().String("deployer-name", "", "deployer name who created the event (OPSLEVEL_DEPLOYER_NAME)")
-	deployCreateCmd.Flags().String("deployer-email", "", "deployer email who created the event (OPSLEVEL_DEPLOYER_EMAIL)")
+	deployCreateCmd.Flags().String("commit-message", "", "git commit message associated with the event (OPSLEVEL_DEPLOYER_EMAIL)")
+	viper.BindEnv("commit-message", "OPSLEVEL_COMMIT_MESSAGE", "OL_COMMIT_MESSAGE")
 
 	deployCreateCmd.Flags().String("commit-sha", "", "git commit sha associated with the event (OPSLEVEL_DEPLOYER_NAME)")
-	deployCreateCmd.Flags().String("commit-message", "", "git commit message associated with the event (OPSLEVEL_DEPLOYER_EMAIL)")
-	viper.BindPFlags(deployCreateCmd.Flags())
-	viper.BindEnv("integration-url", "OPSLEVEL_INTEGRATION_URL", "OL_INTEGRATION_URL")
-	viper.BindEnv("dry-run", "OPSLEVEL_DRY_RUN", "OL_DRY_RUN")
-	viper.BindEnv("git-path", "OPSLEVEL_GIT_PATH", "OL_GIT_PATH")
-	viper.BindEnv("deploy-number", "OPSLEVEL_DEPLOY_NUMBER", "OL_DEPLOY_NUMBER")
-	viper.BindEnv("deploy-url", "OPSLEVEL_DEPLOY_URL", "OL_DEPLOY_URL")
-	viper.BindEnv("dedup-id", "OPSLEVEL_DEDUP_ID", "OL_DEDUP_ID")
-	viper.BindEnv("deployer-name", "OPSLEVEL_DEPLOYER_NAME", "OL_DEPLOYER_NAME")
-	viper.BindEnv("deployer-email", "OPSLEVEL_DEPLOYER_EMAIL", "OL_DEPLOYER_EMAIL")
 	viper.BindEnv("commit-sha", "OPSLEVEL_COMMIT_SHA", "OL_COMMIT_SHA")
-	viper.BindEnv("commit-message", "OPSLEVEL_COMMIT_MESSAGE", "OL_COMMIT_MESSAGE")
+
+	deployCreateCmd.Flags().String("dedup-id", "", "dedup id of the event (OPSLEVEL_DEDUP_ID)")
+	viper.BindEnv("dedup-id", "OPSLEVEL_DEDUP_ID", "OL_DEDUP_ID")
+
+	deployCreateCmd.Flags().String("deploy-number", "", "deploy number of the event (OPSLEVEL_DEPLOY_NUMBER)")
+	viper.BindEnv("deploy-number", "OPSLEVEL_DEPLOY_NUMBER", "OL_DEPLOY_NUMBER")
+
+	deployCreateCmd.Flags().String("deploy-url", "", "url the event will link back to (OPSLEVEL_DEPLOY_URL)")
+	viper.BindEnv("deploy-url", "OPSLEVEL_DEPLOY_URL", "OL_DEPLOY_URL")
+
+	deployCreateCmd.Flags().String("deployer-email", "", "deployer email who created the event (OPSLEVEL_DEPLOYER_EMAIL)")
+	viper.BindEnv("deployer-email", "OPSLEVEL_DEPLOYER_EMAIL", "OL_DEPLOYER_EMAIL")
+
+	deployCreateCmd.Flags().String("deployer-name", "", "deployer name who created the event (OPSLEVEL_DEPLOYER_NAME)")
+	viper.BindEnv("deployer-name", "OPSLEVEL_DEPLOYER_NAME", "OL_DEPLOYER_NAME")
+
+	deployCreateCmd.Flags().String("environment", "", "environment name of the event (OPSLEVEL_ENVIRONMENT)")
+	viper.BindEnv("environment", "OPSLEVEL_ENVIRONMENT", "OL_ENVIRONMENT")
+
+	deployCreateCmd.Flags().String("git-path", "./", "relative path to grab the git commit info from (if git repo is found overrides all commit details)")
+	viper.BindEnv("git-path", "OPSLEVEL_GIT_PATH", "OL_GIT_PATH")
+
+	deployCreateCmd.Flags().StringP("description", "d", "", "description of the event (OPSLEVEL_DESCRIPTION)")
+	viper.BindEnv("description", "OPSLEVEL_DESCRIPTION", "OL_DESCRIPTION")
+
+	deployCreateCmd.Flags().StringP("service", "s", "", "service alias for the event (OPSLEVEL_SERVICE)")
+	viper.BindEnv("service", "OPSLEVEL_SERVICE", "OL_SERVICE")
+
+	deployCreateCmd.Flags().StringVarP(&integrationUrl, "integration-url", "i", "", "OpsLevel integration url (OPSLEVEL_INTEGRATION_URL)")
+	viper.BindEnv("integration-url", "OPSLEVEL_INTEGRATION_URL", "OL_INTEGRATION_URL")
+
+	viper.BindPFlags(deployCreateCmd.Flags())
 }
 
 func readCreateConfigAsDeployEvent() (*DeployEvent, error) {

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -14,8 +14,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var integrationUrl string
-
 type Deployer struct {
 	Email string `validate:"required" json:"email" default:"automation@opslevel.com"`
 	Name  string `json:"name,omitempty"`
@@ -52,6 +50,7 @@ var deployCreateCmd = &cobra.Command{
 	Short: "Create deployment events",
 	Long:  "Create deployment events (report a deployment to OpsLevel using an integration url)",
 	Run: func(cmd *cobra.Command, args []string) {
+		integrationUrl := viper.GetString("integration-url")
 		if integrationUrl == "" {
 			log.Error().Msg("Please provide '--integration-url' to send the deployment information to")
 			os.Exit(1)
@@ -120,7 +119,7 @@ func init() {
 	deployCreateCmd.Flags().StringP("service", "s", "", "service alias for the event (OPSLEVEL_SERVICE)")
 	viper.BindEnv("service", "OPSLEVEL_SERVICE", "OL_SERVICE")
 
-	deployCreateCmd.Flags().StringVarP(&integrationUrl, "integration-url", "i", "", "OpsLevel integration url (OPSLEVEL_INTEGRATION_URL)")
+	deployCreateCmd.Flags().StringP("integration-url", "i", "", "OpsLevel integration url (OPSLEVEL_INTEGRATION_URL)")
 	viper.BindEnv("integration-url", "OPSLEVEL_INTEGRATION_URL", "OL_INTEGRATION_URL")
 
 	viper.BindPFlags(deployCreateCmd.Flags())


### PR DESCRIPTION
## Issues

Part of https://github.com/OpsLevel/team-platform/issues/368 (GitLab CD integration)

## Why?

While testing the CLI to create deploys for the GitLab CI integration I not all arguments that can be used for `opslevel create deploy` are supported as environment variables, which is confusing. **According to the help menu env vars should be supported for each field.**

## Changelog

- [x] Bind all deploy options to an environment variable, sort the init() function so it's easier to read and notice this issue
- [x] Small refactor to use happy path
- [x] Make a `changie` entry

## Tophatting

Before: 

```
$ OL_DRY_RUN=true OL_COMMIT_SHA=sha123 OL_COMMIT_MESSAGE=msg123 OL_DEDUP_ID=ded123 OL_DEPLOY_NUMBER=num123 OL_DEPLOY_URL=reddit.com OL_DEPLOYER_EMAIL=taimoor@reddit.com OL_DEPLOYER_NAME=taimoor123 OL_ENVIRONMENT=env123 OL_GIT_PATH='./' OL_DESCRIPTION=desc123 OL_SERVICE=service-alias-here ./opslevel create deploy -i google.com -f .
11:55AM INF {"service":"","deployer":{"email":"taimoor@reddit.com","name":"taimoor123"},"deployed_at":"2024-05-23T15:55:16.090975Z","description":"Event Created by OpsLevel CLI","deploy_url":"reddit.com","deploy_number":"num123","commit":{"sha":"sha123","message":"msg123"},"dedup_id":"ded123"}
```

^Is missing service value, environment value, description value [(defaulted to what's here)]( https://github.com/OpsLevel/cli/blob/cc92779051c20b44cc7c7d96839009f319faacdc/src/cmd/deploy.go#L42)

After:

```
$ OL_DRY_RUN=true OL_COMMIT_SHA=sha123 OL_COMMIT_MESSAGE=msg123 OL_DEDUP_ID=ded123 OL_DEPLOY_NUMBER=num123 OL_DEPLOY_URL=reddit.com OL_DEPLOYER_EMAIL=taimoor@reddit.com OL_DEPLOYER_NAME=taimoor123 OL_ENVIRONMENT=env123 OL_GIT_PATH='./' OL_DESCRIPTION=desc123 OL_SERVICE=service-alias-here ./opslevel create deploy -i google.com -f .
11:58AM INF {"service":"service-alias-here","deployer":{"email":"taimoor@reddit.com","name":"taimoor123"},"deployed_at":"2024-05-23T15:58:39.645365Z","description":"desc123","environment":"env123","deploy_url":"reddit.com","deploy_number":"num123","commit":{"sha":"sha123","message":"msg123"},"dedup_id":"ded123"}
```

^Correctly read service, environment, description from the env vars

Before (cannot read integration URL from env var even though it's in the help menu and only the CLI arg works):

```
$ OL_DRY_RUN=true OL_INTEGRATION_URL=reddit.com ./opslevel create deploy -f .
12:17PM ERR Please provide '--integration-url' to send the deployment information to

$ OL_DRY_RUN=true ./opslevel create deploy -f . -i reddit.com
12:17PM INF {"service":"","deployer":{"email":"automation@opslevel.com"},"deployed_at":"2024-05-23T16:17:56.534134Z","description":"Event Created by OpsLevel CLI","commit":{}}
```

After (can read from CLI and env var (no errors)):

```
$ OL_DRY_RUN=true OL_INTEGRATION_URL=reddit.com ./opslevel create deploy -f .
12:16PM INF {"service":"","deployer":{"email":"automation@opslevel.com"},"deployed_at":"2024-05-23T16:16:18.088872Z","description":"Event Created by OpsLevel CLI","commit":{}}

$ OL_DRY_RUN=true ./opslevel create deploy -f . -i reddit.com
12:17PM INF {"service":"","deployer":{"email":"automation@opslevel.com"},"deployed_at":"2024-05-23T16:17:08.266892Z","description":"Event Created by OpsLevel CLI","commit":{}}

```


