### PR TITLE
bugfix - install ca-certs in dockerfile

### DIFF
--- a/.changes/unreleased/Bugfix-20240523-151230.yaml
+++ b/.changes/unreleased/Bugfix-20240523-151230.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Docker image will now install `ca-certificates` during bootstrap
+time: 2024-05-23T15:12:30.528274-04:00

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,6 +3,6 @@ ENV USER_UID=1001 USER_NAME=opslevel
 ENTRYPOINT ["/usr/local/bin/opslevel"]
 WORKDIR /app
 RUN apt-get update && \
-    apt-get install -y jq && \
+    apt-get install -y ca-certificates jq && \
     apt-get purge && apt-get clean && apt-get autoclean
 COPY opslevel /usr/local/bin


### PR DESCRIPTION
Prevents the need for us to install this package whenever we use this image, otherwise trying to send requests to `opslevel.com` fails because of no certs.

Part of https://github.com/OpsLevel/team-platform/issues/368