### PR TITLE
bugfix - attempt to fix release GitHub Action error by pulling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,7 @@ jobs:
           gh release delete ${{ steps.version.outputs.RELEASE_VERSION }} || true
       - name: Ensure Changelog
         run: |
+          git pull --rebase
           git config user.name "OpsLevel Bots"
           git config user.email "bots@opslevel.com"
           if test -f ./.changes/${{ steps.version.outputs.RELEASE_VERSION }}.md


### PR DESCRIPTION
## Error details

Current release (v2024.5.23) does not show up in GitHub or ECR but it has a tag and that's it. 

Error message from release process (tried re-running) [logs](https://github.com/OpsLevel/cli/actions/runs/9213494671/job/25348128376)

```
[main 32b1b8b] Cut Release 'v2024.5.23'
 3 files changed, 12 insertions(+), 4 deletions(-)
 delete mode 100644 .changes/unreleased/Bugfix-20240523-114929.yaml
 create mode 100644 .changes/v2024.5.23.md
To https://github.com/OpsLevel/cli
 ! [rejected]        HEAD -> main (non-fast-forward)
error: failed to push some refs to 'https://github.com/OpsLevel/cli'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.

```

## Issues

Blocking: https://github.com/OpsLevel/team-platform/issues/368

(I can just continue without using the latest docker image if this doesn't get resolved soon.)