### PR TITLE
set goreleaser version 2 in config file, bump version in release work…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
           git tag -f ${{ steps.version.outputs.RELEASE_VERSION }} -m "Cut Release '${{ steps.version.outputs.RELEASE_VERSION }}'"
           git push -f origin refs/tags/${{ steps.version.outputs.RELEASE_VERSION }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5.1.0
+        uses: goreleaser/goreleaser-action@v6.0.0
         with:
           args: release --clean --release-notes=../.changes/${{ steps.version.outputs.RELEASE_VERSION }}.md
           workdir: ./src

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: opslevel
 before:
   hooks:


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add `version: 2` to goreleaser config file
Bump `goreleaser/goreleaser-action` to v6 which uses goreleaser v2 by default

- [X] List your changes here
- [ ] Make a `changie` entry, N/A updates release workflow only

## Tophatting

Test locally with `goreleaser release --clean --snapshot`
