### PR TITLE
opslevel update service command correctly updates fields

### DIFF
--- a/.changes/unreleased/Bugfix-20240718-095431.yaml
+++ b/.changes/unreleased/Bugfix-20240718-095431.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: opslevel update service command correctly updates fields
+time: 2024-07-18T09:54:31.699848-05:00

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -235,7 +235,7 @@ func NullableString(value *string) *opslevel.Nullable[string] {
 	if value == nil {
 		return nil
 	}
-	if *value == "" || *value == "null" {
+	if *value == "" {
 		return opslevel.NewNull()
 	}
 	return opslevel.NewNullableFrom(*value)

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -232,7 +232,10 @@ func convertServiceUpdateInput(input opslevel.ServiceUpdateInput) opslevel.Servi
 }
 
 func NullableString(value *string) *opslevel.Nullable[string] {
-	if value == nil || *value == "" {
+	if value == nil {
+		return nil
+	}
+	if *value == "" || *value == "null" {
 		return opslevel.NewNull()
 	}
 	return opslevel.NewNullableFrom(*value)


### PR DESCRIPTION
## Issues

[Regression with update service command](https://github.com/OpsLevel/cli/issues/302)

## Changelog

Stop updating omitted fields (nil in this case) and only set fields to `null` if string is an empty string or `null`

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
