### PR TITLE
add --ignore-deactivated flag to list user cmd

### DIFF
--- a/.changes/unreleased/Feature-20240815-103102.yaml
+++ b/.changes/unreleased/Feature-20240815-103102.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: list user with --ignore-deactivated flag shows only active users
+time: 2024-08-15T10:31:02.540265-05:00

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@
 brew install opslevel/tap/cli
 ```
 
+#### Curl Download
+
+```sh
+# Note: you can also run without `sudo` and move the binary yourself
+curl -sLS https://raw.githubusercontent.com/OpsLevel/cli/main/install.sh | sudo sh
+```
+
 <!--
 #### Deb
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Function to ensure curl is installed
+has_curl() {
+    _=$(which curl)
+    if [ "$?" = "1" ]; then
+        echo "You need curl to use this script."
+        exit 1
+    fi
+}
+
+# Function to determine the architecture
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64)        ARCH=amd64;;
+        aarch64|arm64) ARCH=arm64;;
+        *)         echo "Unsupported architecture"; exit 1;;
+    esac
+    echo "Detected Architecture: $ARCH"
+}
+
+# Function to determine the OS
+detect_os() {
+    case "$(uname -s)" in
+        Linux*)     OS=linux;;
+        Darwin*)    OS=darwin;;
+        CYGWIN*|MSYS*|MINGW32*|MINGW64*|MINGW*) OS=windows;;
+        *)          echo "Unsupported OS"; exit 1;;
+    esac
+    echo "Detected OS: $OS"
+}
+
+# Version of the OpsLevel CLI to install
+get_version() {
+    VERSION=$(curl -sI https://github.com/OpsLevel/cli/releases/latest | grep -i "location:" | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+    if [ ! $VERSION ]; then
+        echo "Failed while attempting to install OpsLevel's cli. Please manually install:"
+        echo ""
+        echo "Open your web browser and go to https://github.com/OpsLevel/cli?tab=readme-ov-file#installation for instructions."
+        exit 1
+    fi
+}
+
+# Function to download and install the CLI tool
+install_cli() {
+    DOWNLOAD_URL="https://github.com/OpsLevel/cli/releases/download/${VERSION}/opslevel-${OS}-${ARCH}.tar.gz"
+
+    # Temporary directory to store the download
+    TMP_DIR=$(mktemp -d)
+
+    echo "Downloading OpsLevel CLI from $DOWNLOAD_URL ..."
+    curl -L -o "$TMP_DIR/opslevel.tar.gz" "$DOWNLOAD_URL"
+
+    if [ $? -ne 0 ]; then
+        echo "Download failed. Please check the version and try again."
+        exit 1
+    fi
+
+    echo "Extracting the OpsLevel CLI..."
+    tar -xzf "$TMP_DIR/opslevel.tar.gz" -C "$TMP_DIR"
+
+    echo "Installing the OpsLevel CLI to /usr/local/bin ..."
+    sudo mv "$TMP_DIR/opslevel" /usr/local/bin/
+
+    if [ $? -ne 0 ]; then
+        echo "Installation failed."
+        exit 1
+    fi
+
+    echo "Cleaning up..."
+    rm -rf "$TMP_DIR"
+
+    echo "OpsLevel CLI installed successfully!"
+}
+
+# Main script execution
+has_curl
+detect_arch
+detect_os
+get_version
+install_cli

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -102,11 +102,11 @@ opslevel list user --ignore-deactivated
 opslevel list user -o json | jq 'map({"key": .Name, "value": .Role}) | from_entries'
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		// payloadVars should remain nil if '--ignore-deactivated' not set
 		var payloadVars *opslevel.PayloadVariables
+
 		ignoreDeactivated, err := cmd.Flags().GetBool("ignore-deactivated")
-		if err != nil {
-			cobra.CheckErr(err)
-		}
+		cobra.CheckErr(err)
 
 		client := getClientGQL()
 		if ignoreDeactivated {

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -98,10 +98,28 @@ var listUserCmd = &cobra.Command{
 	Short:   "Lists the users",
 	Example: `
 opslevel list user
+opslevel list user --ignore-deactivated
 opslevel list user -o json | jq 'map({"key": .Name, "value": .Role}) | from_entries'
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		resp, err := getClientGQL().ListUsers(nil)
+		var payloadVars *opslevel.PayloadVariables
+		ignoreDeactivated, err := cmd.Flags().GetBool("ignore-deactivated")
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		client := getClientGQL()
+		if ignoreDeactivated {
+			payloadVars = client.InitialPageVariablesPointer()
+			(*payloadVars)["filter"] = &[]opslevel.UsersFilterInput{
+				{
+					Key:  opslevel.UsersFilterEnumDeactivatedAt,
+					Type: opslevel.RefOf(opslevel.BasicTypeEnumEquals),
+				},
+			}
+		}
+
+		resp, err := getClientGQL().ListUsers(payloadVars)
 		cobra.CheckErr(err)
 		list := resp.Nodes
 		sort.Slice(list, func(i, j int) bool {
@@ -205,6 +223,7 @@ EOF
 
 func init() {
 	createUserCmd.Flags().Bool("skip-welcome-email", false, "If this flag is set the welcome e-mail will be skipped from being sent")
+	listUserCmd.Flags().Bool("ignore-deactivated", false, "If this flag is set only return active users")
 
 	exampleCmd.AddCommand(exampleUserCmd)
 	createCmd.AddCommand(createUserCmd)

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -110,13 +110,7 @@ opslevel list user -o json | jq 'map({"key": .Name, "value": .Role}) | from_entr
 
 		client := getClientGQL()
 		if ignoreDeactivated {
-			payloadVars = client.InitialPageVariablesPointer()
-			(*payloadVars)["filter"] = &[]opslevel.UsersFilterInput{
-				{
-					Key:  opslevel.UsersFilterEnumDeactivatedAt,
-					Type: opslevel.RefOf(opslevel.BasicTypeEnumEquals),
-				},
-			}
+			payloadVars = client.InitialPageVariablesPointer().WithoutDeactivedUsers()
 		}
 
 		resp, err := getClientGQL().ListUsers(payloadVars)


### PR DESCRIPTION
## Issues

[As an End User, I can use filtering on the account users listing](https://github.com/OpsLevel/team-platform/issues/202)

## Changelog

- [x] List your changes here
- [x] Make a `changie` entry

## Tophatting

### Run `opslevel list users`
```bash
David    david+pat@opslevel.com    Z2lkOi8vb3BzbGV2ZWwvVXNlci8yNTg5MA  
Deact    deact+pat@opslevel.com    Z2lkOi8vb3BzbGV2ZWwvVXNlci8zMjU4MA  
Kyle     kyle+pat@opslevel.com     Z2lkOi8vb3BzbGV2ZWwvVXNlci8yNTg5Mg  
Taimoor  taimoor+pat@opslevel.com  Z2lkOi8vb3BzbGV2ZWwvVXNlci8yNTg5MQ  
```

### Run `opslevel list users --ignore-deactivated`
```bash
David    david+pat@opslevel.com    Z2lkOi8vb3BzbGV2ZWwvVXNlci8yNTg5MA  
Kyle     kyle+pat@opslevel.com     Z2lkOi8vb3BzbGV2ZWwvVXNlci8yNTg5Mg  
Taimoor  taimoor+pat@opslevel.com  Z2lkOi8vb3BzbGV2ZWwvVXNlci8yNTg5MQ  
```