### PR TITLE
graphql cmd correctly handles errors with field args

### DIFF
--- a/.changes/unreleased/Bugfix-20240819-163947.yaml
+++ b/.changes/unreleased/Bugfix-20240819-163947.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: graphql cmd correctly handles errors with field args
+time: 2024-08-19T16:39:47.306301-05:00

--- a/src/cmd/graphql.go
+++ b/src/cmd/graphql.go
@@ -127,7 +127,9 @@ query ($id: ID!){
 		for _, field := range fields {
 			matches := keyValueExp.FindStringSubmatch(field)
 			value, err := convert(matches[2])
-			handleErr(fmt.Sprintf("error parsing variable '%s'", field), err)
+			if err != nil {
+				handleErr(fmt.Sprintf("error parsing variable '%s'", field), err)
+			}
 			variables[matches[1]] = value
 		}
 


### PR DESCRIPTION
## Issues

[Error: error parsing variable 'owner=platform' | %!w(<nil>)](https://github.com/OpsLevel/cli/issues/320)

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
