### PR TITLE
Kr/property assign args

### DIFF
--- a/.changes/unreleased/Feature-20240823-101332.yaml
+++ b/.changes/unreleased/Feature-20240823-101332.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add ability to specify the owner id or alias and the property definition id
+  or alias on the command line arguments of the `assign property` command
+time: 2024-08-23T10:13:32.68659-05:00

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -96,13 +96,16 @@ var listPropertyCmd = &cobra.Command{
 }
 
 var assignPropertyCmd = &cobra.Command{
-	Use:        "property",
-	Aliases:    []string{"prop"},
-	Short:      "Assign a Property",
-	Long:       `Assign a Property to an Entity by Id or Alias`,
-	Args:       cobra.RangeArgs(0, 2),
-	ArgAliases: []string{"OWNER", "PROPERTY_DEFINITION"},
+	Use:     "property [OWNER] [PROPERTY_DEFINITION]",
+	Aliases: []string{"prop"},
+	Short:   "Assign a Property",
+	Long:    `Assign a Property to an Entity by Id or Alias`,
+	Args:    cobra.RangeArgs(0, 2),
 	Example: fmt.Sprintf(`
+cat << EOF | opslevel assign property my-service my-property -f -
+value: example_value
+EOF
+
 cat << EOF | opslevel assign property -f -
 %s
 EOF`, getYaml[opslevel.PropertyInput]()),

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -96,10 +96,12 @@ var listPropertyCmd = &cobra.Command{
 }
 
 var assignPropertyCmd = &cobra.Command{
-	Use:     "property",
-	Aliases: []string{"prop"},
-	Short:   "Assign a Property",
-	Long:    `Assign a Property to an Entity by Id or Alias`,
+	Use:        "property",
+	Aliases:    []string{"prop"},
+	Short:      "Assign a Property",
+	Long:       `Assign a Property to an Entity by Id or Alias`,
+	Args:       cobra.RangeArgs(0, 2),
+	ArgAliases: []string{"OWNER", "PROPERTY_DEFINITION"},
 	Example: fmt.Sprintf(`
 cat << EOF | opslevel assign property -f -
 %s
@@ -107,6 +109,16 @@ EOF`, getYaml[opslevel.PropertyInput]()),
 	Run: func(cmd *cobra.Command, args []string) {
 		input, err := readResourceInput[opslevel.PropertyInput]()
 		cobra.CheckErr(err)
+
+		switch len(args) {
+		case 0:
+		case 1:
+			input.Owner = *opslevel.NewIdentifier(args[0])
+		case 2:
+			input.Owner = *opslevel.NewIdentifier(args[0])
+			input.Definition = *opslevel.NewIdentifier(args[1])
+		}
+
 		newProperty, err := getClientGQL().PropertyAssign(*input)
 		cobra.CheckErr(err)
 

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -114,7 +114,6 @@ EOF`, getYaml[opslevel.PropertyInput]()),
 		cobra.CheckErr(err)
 
 		switch len(args) {
-		case 0:
 		case 1:
 			input.Owner = *opslevel.NewIdentifier(args[0])
 		case 2:


### PR DESCRIPTION
Resolves #

### Problem

It was raised by @morriswchris that we should take in more commandline args to make setting `IdentifierInput` easier.

https://jk-labs.slack.com/archives/C01K732BV51/p1724424641525339

### Solution

Add 2 optional commandline args the override the data from file input if specified and help make `IdentifierInput` easier to specify.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
