### PR TITLE
Import a csv file to delete users + count flag for services

### DIFF
--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -92,6 +92,10 @@ var listServiceCmd = &cobra.Command{
 		client := getClientGQL()
 		resp, err := client.ListServices(nil)
 		cobra.CheckErr(err)
+		if ok, _ := cmd.Flags().GetBool("count"); ok {
+			fmt.Println(len(resp.Nodes))
+			return
+		}
 		for _, service := range resp.Nodes {
 			if !isJsonOutput() {
 				list = append(list, service)
@@ -249,6 +253,7 @@ func init() {
 	listServiceCmd.PersistentFlags().Bool("dependencies", false, "Include dependencies of each service")
 	listServiceCmd.PersistentFlags().Bool("dependents", false, "Include dependents of each service")
 	listServiceCmd.PersistentFlags().Bool("properties", false, "Include properties of each service")
+	listServiceCmd.PersistentFlags().Bool("count", false, "Print the service count")
 
 	importCmd.AddCommand(importServicesCmd)
 }

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -99,25 +99,19 @@ var listUserCmd = &cobra.Command{
 	Example: `
 opslevel list user
 opslevel list user --ignore-deactivated
-opslevel list user --deactivated
 opslevel list user -o json | jq 'map({"key": .Name, "value": .Role}) | from_entries'
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		// payloadVars should remain nil if '--ignore-deactivated' or --deactivated not set
+		// payloadVars should remain nil if '--ignore-deactivated'
 		var payloadVars *opslevel.PayloadVariables
 
 		ignoreDeactivated, err := cmd.Flags().GetBool("ignore-deactivated")
-		// deactivated, err := cmd.Flags().GetBool("deactivated")
 		cobra.CheckErr(err)
 
 		client := getClientGQL()
 		if ignoreDeactivated {
 			payloadVars = client.InitialPageVariablesPointer().WithoutDeactivedUsers()
 		}
-
-		//if deactivated {
-		//	payloadVars = client.InitialPageVariablesPointer().DeactivedUsers()
-		//}
 
 		resp, err := getClientGQL().ListUsers(payloadVars)
 		cobra.CheckErr(err)
@@ -259,7 +253,6 @@ EOF
 func init() {
 	createUserCmd.Flags().Bool("skip-welcome-email", false, "If this flag is set the welcome e-mail will be skipped from being sent")
 	listUserCmd.Flags().Bool("ignore-deactivated", false, "If this flag is set only return active users")
-	//listUserCmd.Flags().Bool("deactivated", false, "If this flag is set only return deactivated users")
 
 	exampleCmd.AddCommand(exampleUserCmd)
 	createCmd.AddCommand(createUserCmd)

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -102,7 +102,7 @@ opslevel list user --ignore-deactivated
 opslevel list user -o json | jq 'map({"key": .Name, "value": .Role}) | from_entries'
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		// payloadVars should remain nil if '--ignore-deactivated'
+		// payloadVars should remain nil if '--ignore-deactivated' not set
 		var payloadVars *opslevel.PayloadVariables
 
 		ignoreDeactivated, err := cmd.Flags().GetBool("ignore-deactivated")


### PR DESCRIPTION
Resolves #

### Problem

1. The CLI doesnt have a `bulk delete user`s feature. Additional scripting is required to delete multiple users
2. Need a simple solution to get the count of services than list the services and then count it

### Solution

Added `import user delete` in the CLI to support deletion of multiple users by email
Added `count` flag to get a count of the services

### Checklist

- [ -] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
