### PR TITLE
Update .goreleaser.yml

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -48,6 +48,7 @@ dockers:
     - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
     - "--label=org.opencontainers.image.version={{ .Tag }}"
     - "--build-arg=VERSION={{ .Tag }}"
+    - "--platform=linux/arm64"
     goos: linux
     goarch: arm64
 docker_manifests:


### PR DESCRIPTION
Resolves #

### Problem

It seems our CLI image is still not multi-arch

```
 % docker manifest inspect public.ecr.aws/opslevel/cli:latest
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1158,
         "digest": "sha256:7765344f4893a2f1b8023be23a496e32d4ed01544997f220c183cba79f39db3f",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1158,
         "digest": "sha256:7c5ed1a49833b3c9075da05db0b39340ed2249336a5e48b7b9429b45d488e7c7",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
```

### Solution

Be explicit about each image build to ensure each is the arch we expect

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
