### PR TITLE
Add deploy status

### DIFF
--- a/.changes/unreleased/Feature-20250312-122543.yaml
+++ b/.changes/unreleased/Feature-20250312-122543.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add ability to set the status field of a deploy event
+time: 2025-03-12T12:25:43.58387-05:00

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -43,6 +43,7 @@ type DeployEvent struct {
 	DeployNumber string    `json:"deploy_number,omitempty" yaml:"deploy-number"`
 	Commit       Commit    `json:"commit,omitempty"`
 	DedupID      string    `json:"dedup_id,omitempty" yaml:"dedup-id"`
+	Status       string    `json:"status,omitempty" yaml:"status"`
 }
 
 var deployCreateCmd = &cobra.Command{
@@ -116,6 +117,9 @@ func init() {
 	deployCreateCmd.Flags().StringP("description", "d", "", "description of the event (OPSLEVEL_DESCRIPTION)")
 	viper.BindEnv("description", "OPSLEVEL_DESCRIPTION", "OL_DESCRIPTION")
 
+	deployCreateCmd.Flags().String("status", "", "the status of the event, we accept any value but generally you should use one of ['queued','running','canceled','failure','success'] (OPSLEVEL_STATUS)")
+	viper.BindEnv("status", "OPSLEVEL_STATUS", "OL_STATUS")
+
 	deployCreateCmd.Flags().StringP("service", "s", "", "service alias for the event (OPSLEVEL_SERVICE)")
 	viper.BindEnv("service", "OPSLEVEL_SERVICE", "OL_SERVICE")
 
@@ -169,6 +173,9 @@ func fillWithOverrides(evt *DeployEvent) {
 	}
 	if message := viper.GetString("commit-message"); message != "" {
 		evt.Commit.Message = message
+	}
+	if status := viper.GetString("status"); status != "" {
+		evt.Status = status
 	}
 }
 


### PR DESCRIPTION
Resolves #

### Problem

Unable to specify the `status` field in a deploy event

### Solution

Add the ability to set the status field with either `--status=success` or `export OPSLEVEL_STATUS=success`

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
