### PR TITLE
CLI hotfix to make component type on services work

### DIFF
--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -43,6 +43,8 @@ parent:
   alias: "my_system"
 product: "OSS"
 tier: "tier_4"
+type:
+  alias: "mobile-app"
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
 		input, err := readResourceInput[opslevel.ServiceCreateInput]()
@@ -117,15 +119,15 @@ var listServiceCmd = &cobra.Command{
 			common.JsonPrint(json.MarshalIndent(list, "", "    "))
 		} else if isCsvOutput() {
 			w := csv.NewWriter(os.Stdout)
-			w.Write([]string{"NAME", "ID", "ALIASES"})
+			w.Write([]string{"NAME", "ID", "TYPE", "ALIASES"})
 			for _, item := range list {
-				w.Write([]string{item.Name, string(item.Id), strings.Join(item.Aliases, "/")})
+				w.Write([]string{item.Name, string(item.Id), item.Type.Alias, strings.Join(item.Aliases, "/")})
 			}
 			w.Flush()
 		} else {
-			w := common.NewTabWriter("NAME", "ID", "ALIASES")
+			w := common.NewTabWriter("NAME", "ID", "TYPE", "ALIASES")
 			for _, item := range list {
-				fmt.Fprintf(w, "%s\t%s\t%s\t\n", item.Name, item.Id, strings.Join(item.Aliases, ","))
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t\n", item.Name, item.Id, item.Type.Alias, strings.Join(item.Aliases, ","))
 			}
 			w.Flush()
 		}
@@ -151,6 +153,8 @@ parent:
   alias: "my_system"
 product: "OSS"
 tier: "tier_3"
+type:
+  alias: "mobile-app"
 EOF`,
 	Run: func(cmd *cobra.Command, args []string) {
 		input, err := readResourceInput[opslevel.ServiceUpdateInput]()

--- a/src/go.mod
+++ b/src/go.mod
@@ -102,4 +102,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-// replace github.com/opslevel/opslevel-go/v2024 => ./submodules/opslevel-go
+replace github.com/opslevel/opslevel-go/v2024 => ./submodules/opslevel-go

--- a/src/go.sum
+++ b/src/go.sum
@@ -194,8 +194,6 @@ github.com/open-policy-agent/opa v0.67.1 h1:rzy26J6g1X+CKknAcx0Vfbt41KqjuSzx4E0A
 github.com/open-policy-agent/opa v0.67.1/go.mod h1:aqKlHc8E2VAAylYE9x09zJYr/fYzGX+JKne89UGqFzk=
 github.com/opslevel/moredefaults v0.0.0-20240529152742-17d1318a3c12 h1:OQZ3W8kbyCcdS8QUWFTnZd6xtdkfhdckc7Paro7nXio=
 github.com/opslevel/moredefaults v0.0.0-20240529152742-17d1318a3c12/go.mod h1:g2GSXVP6LO+5+AIsnMRPN+BeV86OXuFRTX7HXCDtYeI=
-github.com/opslevel/opslevel-go/v2024 v2024.12.24 h1:yqByehj/HBKcHV2xnZK9ozAhE+qQfXSWxtp6KLS1f9s=
-github.com/opslevel/opslevel-go/v2024 v2024.12.24/go.mod h1:cIwzFyu8HURaGdZKWtKn4pijsyYs8xP8uuDwqgohWgo=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
Resolves #

### Problem

The CLI doesn't have support for creating "components" with a "type" - The greater problem is that its going to take 3-4 weeks to get the CLI updated to opslevel-go 2025 because of the nullability changes

### Solution

Create a patch to the 2024 version of the CLI with just "type" added to the services APIs so that customers can use the CLI still.  The way this works is it abuses the submodule to make a bespoke change to opslevel-go so we can release the CLI with that custom opslevel-go version.

```
% cat << EOF | go run main.go create service -f -
name: "Kyle CLI Test"
type:
  alias: "vendor"
EOF
```

and

```
 % go run main.go list services | grep "Kyle"
Kyle CLI Test                Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zMTQ4NzI  vendor        kyle_cli_test    
```

and

![Screenshot 2025-03-25 at 2 35 12 PM](https://github.com/user-attachments/assets/e670e21c-c023-4c4f-95f3-bd25197fedbf)

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
