### PR TITLE
overhaul contributing based on feedback from evan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,13 @@ The `opslevel-cli` is a command-line interface for interacting with the [OpsLeve
 
 ### Architecture
 
-- **[Cobra](https://github.com/spf13/cobra)** powers our CLI framework. Commands are defined as Go structs with handlers, descriptions, and flags.
+**[Cobra](https://github.com/spf13/cobra)** is the library we use to define our CLI. Commands are defined as Go structs with handlers, descriptions, and flags.
 - **[Viper](https://github.com/spf13/viper)** handles flag parsing, environment variables, and configuration files.
 - Modular command files live under `/cmd`, grouped by functionality (e.g., services, checks, etc.).
 - Commands are registered to `rootCmd` via `init()` functions.
 - 80% of our functionality is provided by opslevel-go and the purpose of this CLI is just to marshal data between the user and opslevel-go in a UX friendly way.
 - Most commands follow the standard CRUD pattern `opslevel create ...`, `opslevel get ...`, `opslevel list ...`, `opslevel update ...`, `opslevel delete ...`, etc.
-- We have `opslevel beta` subcommand for experimental commands that are subject to removal.
+- We have an `opslevel beta` subcommand for experimental commands that are subject to removal.
 
 ---
 
@@ -36,7 +36,7 @@ The `opslevel-cli` is a command-line interface for interacting with the [OpsLeve
 
 ### Clone the Repo
 
-If you're an external contributor, fork the repo:
+If you're an external contributor fork the repo, then:
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/cli.git
@@ -80,6 +80,7 @@ export OPSLEVEL_API_URL=https://self-hosted.opslevel.dev/
 ### Run the CLI Locally
 
 ```sh
+cd ./src
 go run main.go --help
 ```
 
@@ -107,7 +108,7 @@ This way you can effectively work on both the CLI and `opslevel-go` in parallel 
 - Use `task lint` to check for code quality issues locally
 - Use `task fix` to fix formatting, linting, go.mod, and update submodule all in one go
 
-Our CI pipeline will run `task ci` which can also be run locally to debug any issue that might only arrise in CI.
+Our CI pipeline will run `task ci` which can also be run locally to debug any issue that might only arise in CI.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,12 @@ The `opslevel-cli` is a command-line interface for interacting with the [OpsLeve
 ### Architecture
 
 **[Cobra](https://github.com/spf13/cobra)** is the library we use to define our CLI. Commands are defined as Go structs with handlers, descriptions, and flags.
-- **[Viper](https://github.com/spf13/viper)** handles flag parsing, environment variables, and configuration files.
+- **[Viper](https://github.com/spf13/viper)** handles flag parsing, environment variables, and configuration files.  Examples of our usage of it are [here](https://github.com/OpsLevel/cli/blob/main/src/cmd/root.go#L44) and [here](https://github.com/OpsLevel/cli/blob/main/src/cmd/policy.go#L246)
 - Modular command files live under `/cmd`, grouped by functionality (e.g., services, checks, etc.).
 - Commands are registered to `rootCmd` via `init()` functions.
 - 80% of our functionality is provided by opslevel-go and the purpose of this CLI is just to marshal data between the user and opslevel-go in a UX friendly way.
 - Most commands follow the standard CRUD pattern `opslevel create ...`, `opslevel get ...`, `opslevel list ...`, `opslevel update ...`, `opslevel delete ...`, etc.
-- We have an `opslevel beta` subcommand for experimental commands that are subject to removal.
+- We have an `opslevel beta` subcommand for experimental commands that are subject to change.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,24 +30,6 @@ The `opslevel-cli` is a command-line interface for interacting with the [OpsLeve
 - Most commands follow the standard CRUD pattern `opslevel create ...`, `opslevel get ...`, `opslevel list ...`, `opslevel update ...`, `opslevel delete ...`, etc.
 - We have `opslevel beta` subcommand for experimental commands that are subject to removal.
 
-### Minimal Command Example
-
-```go
-var exampleCmd = &cobra.Command{
-    Use:   "example",
-    Short: "Hello World Command",
-    Long:  "Hello World Command to show how an example command works",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        log.Info().Msg("Hello World!")
-        return nil
-    },
-}
-
-func init() {
-    rootCmd.AddCommand(exampleCmd)
-}
-```
-
 ---
 
 ## Getting Started
@@ -103,8 +85,9 @@ go run main.go --help
 
 This is the easiest way to test your changes live.
 
-### Using a Local `opslevel-go` Branch
+### Using a commit from an `opslevel-go` Branch
 
+Sometimes you will need to make CLI changes in tandem with changes to [`opslevel-go`](https://github.com/OpsLevel/opslevel-go). 
 To test changes from a local branch of [`opslevel-go`](https://github.com/OpsLevel/opslevel-go):
 
 ```sh
@@ -116,6 +99,15 @@ git -C ./src/submodules/opslevel-go checkout --track origin/my-feature-branch
 ```
 
 All CLI calls will now use your local `opslevel-go` code checked out into the submodule at `./src/submodules/opslevel-go`.
+This way you can effectively work on both the CLI and `opslevel-go` in parallel if needed.
+
+## Testing & Tooling
+
+- Use `task test` to run tests locally
+- Use `task lint` to check for code quality issues locally
+- Use `task fix` to fix formatting, linting, go.mod, and update submodule all in one go
+
+Our CI pipeline will run `task ci` which can also be run locally to debug any issue that might only arrise in CI.
 
 ---
 
@@ -150,15 +142,26 @@ Once approved and merged, your change will be included in the next release.
 - Flags and environment variables should be registered with Viper for consistency
 - Prefer readable, minimalistic command logic — delegate heavy logic to opslevel-go unless it's not possible
 
----
+### Minimal Command Example
 
-## Testing & Tooling
+The following shows the minimum amount of code needed to create a command.  There are a plethora of commands already registered to the root command, so this is just an example of how to create a new command.
+Please take a look at the existing commands to get a feel for how they work and whats possible.
 
-- Use `task test` to run tests
-- Use `task lint` to check for code quality issues
-- Add tests alongside any new functionality
+```go
+var exampleCmd = &cobra.Command{
+    Use:   "example",
+    Short: "Hello World Command",
+    Long:  "Hello World Command to show how an example command works",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        log.Info().Msg("Hello World!")
+        return nil
+    },
+}
 
-Our CI pipeline will run `task ci` which can also be run locally to debug any issue that might only arrise in CI.
+func init() {
+    rootCmd.AddCommand(exampleCmd)
+}
+```
 
 ---
 


### PR DESCRIPTION
Resolves #

### Problem

The CONTRIBUTING.md was too high level and beginner friendly for more experianced devs.  Additionally the document hadn't really been touched since the inception of the CLI

### Solution

Rewrite the document for more internal use while still being relevant for external contributors.  Add more information around the project architecture, how to get started, what helpers have been added to the repo and generally just have a better flow / structure. 

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
