### PR TITLE
drop --remote flag from submodule setup, use --recursive Just In Case

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,7 +68,7 @@ tasks:
     cmds:
       - cmd: echo "Setting up opslevel-go workspace..."
         silent: true
-      - git -C .. submodule update --init --remote
+      - git -C .. submodule update --init --recursive
       - go work init || true
       - go work use . submodules/opslevel-go
       - cmd: echo "opslevel-go workspace ready!"


### PR DESCRIPTION
Resolves #

### Problem

`task setup` will checkout/update the submodule to the latest commit on the remote branch (I'm guessing main) instead of what's been "pinned" / set 

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Don't use `--remote` [docs](https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt---remote)

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
