### PR TITLE
Ignore built binary path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ go.work*
 **coverage.txt
 src/*.yaml
 .vscode/
+src/cli


### PR DESCRIPTION
If you build the CLI this is the path it produces, would be nice if that didn't produce a git diff.