### PR TITLE
Add 'mcp' to mcp graphql UA

### DIFF
--- a/src/cmd/mcp.go
+++ b/src/cmd/mcp.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/opslevel/cli/common"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -32,12 +34,13 @@ var mcpCmd = &cobra.Command{
 			"1.0.0",
 		)
 
+		client := common.NewGraphClient(fmt.Sprintf("mcp-%s", version))
+
 		// Register Teams
 		s.AddTool(
 			mcp.NewTool("teams",
 				mcp.WithDescription("Get all the team names, identifiers and metadata for the opslevel account.  Teams are owners of other objects in opslevel. Only use this if you need to search all teams.")),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				client := getClientGQL()
 				resp, err := client.ListTeams(nil)
 				if err != nil {
 					return nil, err
@@ -53,7 +56,6 @@ var mcpCmd = &cobra.Command{
 		s.AddTool(
 			mcp.NewTool("users", mcp.WithDescription("Get all the user names, e-mail addresses and metadata for the opslevel account.  Users are the people in opslevel. Only use this if you need to search all users.")),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				client := getClientGQL()
 				resp, err := client.ListUsers(nil)
 				if err != nil {
 					return nil, err
@@ -69,7 +71,6 @@ var mcpCmd = &cobra.Command{
 		s.AddTool(
 			mcp.NewTool("actions", mcp.WithDescription("Get all the information about actions the user can run in the opslevel account")),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				client := getClientGQL()
 				resp, err := client.ListTriggerDefinitions(nil)
 				if err != nil {
 					return nil, err
@@ -85,7 +86,6 @@ var mcpCmd = &cobra.Command{
 		s.AddTool(
 			mcp.NewTool("filters", mcp.WithDescription("Get all the rubric filter names and which predicates they have for the opslevel account")),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				client := getClientGQL()
 				resp, err := client.ListFilters(nil)
 				if err != nil {
 					return nil, err
@@ -101,7 +101,6 @@ var mcpCmd = &cobra.Command{
 		s.AddTool(
 			mcp.NewTool("components", mcp.WithDescription("Get all the components in the opslevel account.  Components are objects in opslevel that represent things like apis, libraries, services, frontends, backends, etc.")),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				client := getClientGQL()
 				resp, err := client.ListServices(nil)
 				if err != nil {
 					return nil, err
@@ -126,7 +125,6 @@ var mcpCmd = &cobra.Command{
 		s.AddTool(
 			mcp.NewTool("infrastructure", mcp.WithDescription("Get all the infrastructure in the opslevel account.  Infrastructure are objects in opslevel that represent cloud provider resources like vpc, databases, caches, networks, vms, etc.")),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				client := getClientGQL()
 				resp, err := client.ListInfrastructure(nil)
 				if err != nil {
 					return nil, err
@@ -142,7 +140,6 @@ var mcpCmd = &cobra.Command{
 		s.AddTool(
 			mcp.NewTool("domains", mcp.WithDescription("Get all the domains in the opslevel account.  Domains are objects in opslevel that represent a top-level abstraction used to organize and categorize software systems.")),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				client := getClientGQL()
 				resp, err := client.ListDomains(nil)
 				if err != nil {
 					return nil, err
@@ -158,7 +155,6 @@ var mcpCmd = &cobra.Command{
 		s.AddTool(
 			mcp.NewTool("systems", mcp.WithDescription("Get all the systems in the opslevel account.  Systems are objects in opslevel that represent a grouping of services or components that act together to serve a business function or process.")),
 			func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				client := getClientGQL()
 				resp, err := client.ListSystems(nil)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
This requires creating a separate graphql client, but we only do that if we are running the MCP server so the overhead is minimal.