### PR TITLE
Kr/upgrade opslevel go 2025

### DIFF
--- a/src/cmd/account.go
+++ b/src/cmd/account.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"

--- a/src/cmd/action.go
+++ b/src/cmd/action.go
@@ -58,7 +58,7 @@ EOF`,
 			cobra.CheckErr(err)
 			result, err := getClientGQL().CreateWebhookAction(*input)
 			cobra.CheckErr(err)
-			fmt.Printf("created webhook action: %s\n", result.Id)
+			fmt.Printf("created webhook action: %s\n", string(result.CustomActionsId.Id))
 		default:
 			err := fmt.Errorf("unknown action type: '%s'", actionType)
 			cobra.CheckErr(err)
@@ -94,7 +94,7 @@ var listActionCmd = &cobra.Command{
 		} else {
 			w := common.NewTabWriter("ID", "NAME", "HTTP_METHOD", "WEBHOOK_URL")
 			for _, item := range list {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", item.Id, item.Name, item.HTTPMethod, item.WebhookURL)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", string(item.CustomActionsId.Id), item.Name, item.HttpMethod, item.WebhookUrl)
 			}
 			w.Flush()
 		}

--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 	"github.com/rs/zerolog/log"

--- a/src/cmd/dependency.go
+++ b/src/cmd/dependency.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/deploy.go
+++ b/src/cmd/deploy.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/creasty/defaults"
 	"github.com/go-git/go-git/v5"

--- a/src/cmd/document.go
+++ b/src/cmd/document.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"

--- a/src/cmd/domain.go
+++ b/src/cmd/domain.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/opslevel/cli/common"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/example.go
+++ b/src/cmd/example.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"

--- a/src/cmd/filter.go
+++ b/src/cmd/filter.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"

--- a/src/cmd/filter.go
+++ b/src/cmd/filter.go
@@ -108,7 +108,7 @@ EOF`,
 		// by adding in the first argument.
 		updateInput := &opslevel.FilterUpdateInput{
 			Id:         *opslevel.NewID(args[0]),
-			Name:       &input.Name,
+			Name:       opslevel.NewNullableFrom(input.Name),
 			Predicates: input.Predicates,
 			Connective: input.Connective,
 		}

--- a/src/cmd/graphql.go
+++ b/src/cmd/graphql.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/itchyny/gojq"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/infra.go
+++ b/src/cmd/infra.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/opslevel/cli/common"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"

--- a/src/cmd/infra.go
+++ b/src/cmd/infra.go
@@ -173,7 +173,7 @@ opslevel list infra -o json | jq 'map(select(.type == "Database") | .data | from
 			w := csv.NewWriter(os.Stdout)
 			w.Write([]string{"NAME", "ID", "ALIASES"})
 			for _, item := range list {
-				w.Write([]string{item.Name, item.Id, strings.Join(item.Aliases, "/")})
+				w.Write([]string{item.Name, string(item.Id), strings.Join(item.Aliases, "/")})
 			}
 			w.Flush()
 		} else {
@@ -216,7 +216,7 @@ EOF`,
 		cobra.CheckErr(err)
 		result, err := getClientGQL().UpdateInfrastructure(key, *input)
 		cobra.CheckErr(err)
-		fmt.Println(result.Id)
+		fmt.Println(string(result.Id))
 	},
 }
 

--- a/src/cmd/integration.go
+++ b/src/cmd/integration.go
@@ -248,7 +248,7 @@ EOF
 			cobra.CheckErr(err)
 			result, err = getClientGQL().UpdateEventIntegration(opslevel.EventIntegrationUpdateInput{
 				Id:   opslevel.ID(args[0]),
-				Name: *eventIntegrationInput.Name,
+				Name: eventIntegrationInput.Name.Value,
 			})
 			cobra.CheckErr(err)
 		} else {

--- a/src/cmd/integration.go
+++ b/src/cmd/integration.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/opslevel/cli/common"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/maturity.go
+++ b/src/cmd/maturity.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/opslevel/cli/common"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/policy.go
+++ b/src/cmd/policy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/types"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/relvacode/iso8601"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -61,11 +61,7 @@ var listPropertyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var service *opslevel.Service
 		var err error
-		if opslevel.IsID(args[0]) {
-			service, err = getClientGQL().GetService(*opslevel.NewID(args[0]))
-		} else {
-			service, err = getClientGQL().GetServiceWithAlias(args[0])
-		}
+		service, err = getClientGQL().GetService(args[0])
 		cobra.CheckErr(err)
 		properties, err := service.GetProperties(getClientGQL(), nil)
 		cobra.CheckErr(err)
@@ -227,7 +223,8 @@ func readPropertyDefinitionInput() (*opslevel.PropertyDefinitionInput, error) {
 		propDefInput.Description = opslevel.RefOf(description)
 	}
 	if propertyDisplayStatus, ok := data["propertyDisplayStatus"].(string); ok {
-		propDefInput.PropertyDisplayStatus = opslevel.RefOf(opslevel.PropertyDisplayStatusEnum(propertyDisplayStatus))
+		status := opslevel.PropertyDisplayStatusEnum(propertyDisplayStatus)
+		propDefInput.PropertyDisplayStatus = &status
 	}
 
 	return &propDefInput, nil

--- a/src/cmd/property.go
+++ b/src/cmd/property.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 

--- a/src/cmd/repository.go
+++ b/src/cmd/repository.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"

--- a/src/cmd/rubric.go
+++ b/src/cmd/rubric.go
@@ -131,13 +131,13 @@ var listLevelCmd = &cobra.Command{
 	Short:   "Lists rubric levels",
 	Long:    `Lists rubric levels`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list, err := getClientGQL().ListLevels()
+		resp, err := getClientGQL().ListLevels(nil)
 		cobra.CheckErr(err)
 		if isJsonOutput() {
-			common.JsonPrint(json.MarshalIndent(list, "", "    "))
+			common.JsonPrint(json.MarshalIndent(resp.Nodes, "", "    "))
 		} else {
 			w := common.NewTabWriter("NAME", "ALIAS", "ID")
-			for _, item := range list {
+			for _, item := range resp.Nodes {
 				fmt.Fprintf(w, "%s\t%s\t%s\t\n", item.Name, item.Alias, item.Id)
 			}
 			w.Flush()

--- a/src/cmd/rubric.go
+++ b/src/cmd/rubric.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"

--- a/src/cmd/scorecard.go
+++ b/src/cmd/scorecard.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"

--- a/src/cmd/scorecard.go
+++ b/src/cmd/scorecard.go
@@ -73,7 +73,7 @@ opslevel list scorecards -o json | jq 'map( {(.Name): (.ServiceCount)} )'
 		} else {
 			w := common.NewTabWriter("ID", "NAME", "PASSING_CHECKS", "CHECKS_COUNT", "SERVICE_COUNT")
 			for _, item := range list {
-				fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\n", item.Id, item.Name, item.PassingChecks, item.ChecksCount, item.ServiceCount)
+				fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\n", item.Id, item.Name, item.PassingChecks, item.TotalChecks, item.ServiceCount)
 			}
 			w.Flush()
 		}

--- a/src/cmd/secret.go
+++ b/src/cmd/secret.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 

--- a/src/cmd/secret.go
+++ b/src/cmd/secret.go
@@ -38,7 +38,7 @@ EOF`,
 		newSecret, err := getClientGQL().CreateSecret(secretAlias, *input)
 		cobra.CheckErr(err)
 
-		fmt.Println(newSecret.ID)
+		fmt.Printf(string(newSecret.Id))
 	},
 }
 
@@ -53,7 +53,7 @@ var getSecretCmd = &cobra.Command{
 		result, err := getClientGQL().GetSecret(identifier)
 		cobra.CheckErr(err)
 
-		common.WasFound(result.ID == "", identifier)
+		common.WasFound(result.Id == "", identifier)
 		if isYamlOutput() {
 			common.YamlPrint(result)
 		} else {
@@ -77,7 +77,7 @@ var listSecretsCmd = &cobra.Command{
 		} else {
 			w := common.NewTabWriter("ALIAS", "ID", "OWNER", "UPDATED_AT")
 			for _, item := range list {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", item.Alias, item.ID, item.Owner.Alias, item.Timestamps.UpdatedAt.Time)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", item.Alias, item.Id, item.Owner.Alias, item.Timestamps.UpdatedAt.Time)
 			}
 			w.Flush()
 		}
@@ -102,7 +102,7 @@ EOF`,
 		cobra.CheckErr(err)
 		secret, err := getClientGQL().UpdateSecret(secretId, *input)
 		cobra.CheckErr(err)
-		fmt.Println(secret.ID)
+		fmt.Printf(string(secret.Id))
 	},
 }
 
@@ -116,7 +116,7 @@ var deleteSecretCmd = &cobra.Command{
 		secretId := args[0]
 		err := getClientGQL().DeleteSecret(secretId)
 		cobra.CheckErr(err)
-		fmt.Printf("deleted '%s' secret\n", secretId)
+		fmt.Printf("deleted secret: %s\n", secretId)
 	},
 }
 

--- a/src/cmd/service.go
+++ b/src/cmd/service.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/rs/zerolog/log"
 

--- a/src/cmd/system.go
+++ b/src/cmd/system.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/opslevel/cli/common"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/tag.go
+++ b/src/cmd/tag.go
@@ -50,10 +50,11 @@ opslevel create tag --type=Infra my-infra-alias foo bar
 			input := opslevel.TagAssignInput{Tags: []opslevel.TagInput{tagInput}}
 
 			if opslevel.IsID(resource) {
-				input.Id = opslevel.NewID(resource)
+				input.Id = opslevel.RefOf(opslevel.ID(resource))
 			} else {
 				input.Alias = opslevel.RefOf(resource)
-				input.Type = opslevel.RefOf(opslevel.TaggableResource(resourceType))
+				resourceType := opslevel.TaggableResource(resourceType)
+				input.Type = &resourceType
 			}
 
 			result, err := getClientGQL().AssignTag(input)
@@ -67,8 +68,9 @@ opslevel create tag --type=Infra my-infra-alias foo bar
 			if opslevel.IsID(resource) {
 				input.Id = opslevel.NewID(resource)
 			} else {
-				input.Alias = opslevel.RefOf(resource)
-				input.Type = opslevel.RefOf(opslevel.TaggableResource(resourceType))
+				input.Alias = &resource
+				resourceType := opslevel.TaggableResource(resourceType)
+				input.Type = &resourceType
 			}
 
 			result, err := getClientGQL().CreateTag(input)
@@ -155,8 +157,8 @@ opslevel update tag XXX_TAG_ID_XXX foo baz
 
 		input := opslevel.TagUpdateInput{
 			Id:    opslevel.ID(tag),
-			Key:   opslevel.RefOf(key),
-			Value: opslevel.RefOf(value),
+			Key:   &key,
+			Value: &value,
 		}
 
 		result, err := getClientGQL().UpdateTag(input)

--- a/src/cmd/tag.go
+++ b/src/cmd/tag.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/opslevel/cli/common"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"golang.org/x/exp/slices"
 
 	"github.com/spf13/cobra"

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -117,12 +117,12 @@ opslevel create contact --type=email my-team team@example.com "Mailing List"`,
 		}
 		cobra.CheckErr(err)
 		common.WasFound(team.Id == "", key)
-		contactInput := opslevel.CreateContactSlack(address, &displayName)
+		contactInput := opslevel.CreateContactSlack(displayName, opslevel.RefOf(address))
 		switch contactType {
 		case string(opslevel.ContactTypeEmail):
-			contactInput = opslevel.CreateContactEmail(address, &displayName)
+			contactInput = opslevel.CreateContactEmail(displayName, opslevel.RefOf(address))
 		case string(opslevel.ContactTypeWeb):
-			contactInput = opslevel.CreateContactWeb(address, &displayName)
+			contactInput = opslevel.CreateContactWeb(displayName, opslevel.RefOf(address))
 		}
 		contact, err := getClientGQL().AddContact(team.TeamId.Alias, contactInput)
 		cobra.CheckErr(err)

--- a/src/cmd/team.go
+++ b/src/cmd/team.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/rs/zerolog/log"
 
 	"github.com/opslevel/cli/common"

--- a/src/cmd/team_test.go
+++ b/src/cmd/team_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/opslevel/cli/cmd"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 )
 
 const (

--- a/src/cmd/team_test.go
+++ b/src/cmd/team_test.go
@@ -30,7 +30,7 @@ func Test_TeamCRUD(t *testing.T) {
 		t.Fatal(err)
 	}
 	if createdTeam.Name != teamToCreate.Name ||
-		createdTeam.Responsibilities != *teamToCreate.Responsibilities {
+		createdTeam.Responsibilities != (*teamToCreate.Responsibilities).Value {
 		t.Errorf("Create 'team' failed, expected team '%+v' but got '%+v'", teamToCreate, createdTeam)
 	}
 

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/gosimple/slug"
 	"github.com/spf13/cobra"

--- a/src/cmd/terraform.go
+++ b/src/cmd/terraform.go
@@ -380,9 +380,9 @@ func exportRubric(c *opslevel.Client, config *os.File, shell *os.File) {
   index = %d
 }
 `
-	levels, err := c.ListLevels()
+	levels, err := c.ListLevels(nil)
 	cobra.CheckErr(err)
-	for _, level := range levels {
+	for _, level := range levels.Nodes {
 		config.WriteString(templateConfig(levelConfig, level.Alias, level.Name, level.Description, level.Index))
 		shell.WriteString(fmt.Sprintf("terraform import opslevel_rubric_level.%s %s\n", level.Alias, level.Id))
 	}

--- a/src/cmd/tools.go
+++ b/src/cmd/tools.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/opslevel/cli/common"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/trigger_definition.go
+++ b/src/cmd/trigger_definition.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/opslevel/cli/common"
 	"github.com/spf13/cobra"

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/opslevel/cli/common"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -53,7 +53,7 @@ opslevel create user "jane@example.com" "Jane Doe" Admin --skip-send-invite --sk
 
 		userInput := opslevel.UserInput{
 			Name:             opslevel.RefOf(name),
-			Role:             opslevel.RefOf(role),
+			Role:             &role,
 			SkipWelcomeEmail: opslevel.RefOf(skipEmail),
 		}
 		resource, err := getClientGQL().InviteUser(email, userInput, !skipSendInvite)
@@ -130,13 +130,13 @@ opslevel list user -o json | jq 'map({"key": .Name, "value": .Role}) | from_entr
 			w := csv.NewWriter(os.Stdout)
 			w.Write([]string{"ID", "EMAIL", "NAME", "ROLE", "URL"})
 			for _, item := range list {
-				w.Write([]string{string(item.Id), item.Email, item.Name, string(item.Role), item.HTMLUrl})
+				w.Write([]string{string(item.Id), item.Email, item.Name, string(item.Role), item.HtmlUrl})
 			}
 			w.Flush()
 		} else {
-			w := common.NewTabWriter("NAME", "EMAIL", "ID")
+			w := common.NewTabWriter("NAME", "EMAIL", "ROLE", "ID")
 			for _, item := range list {
-				fmt.Fprintf(w, "%s\t%s\t%s\t\n", item.Name, item.Email, item.Id)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", item.Name, item.Email, string(item.Role), item.Id)
 			}
 			w.Flush()
 		}
@@ -191,10 +191,12 @@ EOF
 			userRole := opslevel.UserRoleUser
 			if slices.Contains(opslevel.AllUserRole, role) {
 				userRole = opslevel.UserRole(role)
+			} else {
+				log.Warn().Msgf("user '%s' has invalid role '%s' defaulting role to 'User'", name, role)
 			}
 			input := opslevel.UserInput{
 				Name:             opslevel.RefOf(name),
-				Role:             opslevel.RefOf(userRole),
+				Role:             &userRole,
 				SkipWelcomeEmail: opslevel.RefOf(skipWelcomeEmail),
 			}
 			user, err := getClientGQL().InviteUser(email, input, !skipSendInvite)

--- a/src/cmd/user_test.go
+++ b/src/cmd/user_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/opslevel/opslevel-go/v2025"
 )
 
-const (
+var (
 	defaultUserRole = opslevel.UserRoleUser
 	userFileName    = "test_user.yaml"
 	userName        = "CLI Test User"
@@ -17,8 +17,7 @@ const (
 
 func Test_UserCRUD(t *testing.T) {
 	expectedUser := opslevel.User{
-		UserId: opslevel.UserId{Email: "testcli+pat@opslevel.com"},
-		Name:   userName,
+		UserId: opslevel.UserId{Email: "testcli+pat@opslevel.com", Name: userName},
 	}
 	// Create User
 	userId, err := createUser(expectedUser)
@@ -34,14 +33,13 @@ func Test_UserCRUD(t *testing.T) {
 	if createdUser.Name != expectedUser.Name ||
 		createdUser.Email != expectedUser.Email ||
 		string(createdUser.Role) != string(defaultUserRole) ||
-		!strings.HasPrefix(createdUser.HTMLUrl, "https://app.opslevel.com/users/") {
+		!strings.HasPrefix(createdUser.HtmlUrl, "https://app.opslevel.com/users/") {
 		t.Errorf("Create 'user' failed, expected user '%+v' but got '%+v'", expectedUser, createdUser)
 	}
 
 	// Update User
 	expectedUpdatedUser := opslevel.User{
 		UserId: createdUser.UserId,
-		Name:   createdUser.Name,
 		Role:   opslevel.UserRoleTeamMember,
 	}
 	updatedUserId, err := updateUser(string(createdUser.Id), expectedUpdatedUser)

--- a/src/cmd/user_test.go
+++ b/src/cmd/user_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/opslevel/cli/cmd"
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 )
 
 const (

--- a/src/common/client.go
+++ b/src/common/client.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/src/common/prompts.go
+++ b/src/common/prompts.go
@@ -37,7 +37,7 @@ func PromptForCategories(client *opslevel.Client) (*opslevel.Category, error) {
 }
 
 func PromptForLevels(client *opslevel.Client) (*opslevel.Level, error) {
-	list, err := client.ListLevels()
+	resp, err := client.ListLevels(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func PromptForLevels(client *opslevel.Client) (*opslevel.Level, error) {
 	}
 
 	var filteredList []opslevel.Level
-	for _, val := range list {
+	for _, val := range resp.Nodes {
 		if val.Index != 0 {
 			filteredList = append(filteredList, val)
 		}

--- a/src/common/prompts.go
+++ b/src/common/prompts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/opslevel/opslevel-go/v2025"
 
 	"github.com/manifoldco/promptui"
 )

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,8 +1,8 @@
 module github.com/opslevel/cli
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.4
+toolchain go1.24.2
 
 require (
 	github.com/creasty/defaults v1.8.0
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/open-policy-agent/opa v0.67.1
-	github.com/opslevel/opslevel-go/v2024 v2024.12.24
+	github.com/opslevel/opslevel-go/v2025 v2025.5.28
 	github.com/relvacode/iso8601 v1.6.0
 	github.com/rocktavious/autopilot v0.1.5
 	github.com/rs/zerolog v1.34.0
@@ -47,7 +47,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.25.0 // indirect
+	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -56,7 +56,7 @@ require (
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
-	github.com/hasura/go-graphql-client v0.13.1 // indirect
+	github.com/hasura/go-graphql-client v0.14.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -101,4 +101,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/opslevel/opslevel-go/v2024 => ./submodules/opslevel-go
+replace github.com/opslevel/opslevel-go/v2025 => ./submodules/opslevel-go

--- a/src/go.sum
+++ b/src/go.sum
@@ -103,8 +103,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.25.0 h1:5Dh7cjvzR7BRZadnsVOzPhWsrwUr0nmsZJxEAnFLNO8=
-github.com/go-playground/validator/v10 v10.25.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
+github.com/go-playground/validator/v10 v10.26.0 h1:SP05Nqhjcvz81uJaRfEV0YBSSSGMc/iMaVtFbr3Sw2k=
+github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
@@ -143,8 +143,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
-github.com/hasura/go-graphql-client v0.13.1 h1:kKbjhxhpwz58usVl+Xvgah/TDha5K2akNTRQdsEHN6U=
-github.com/hasura/go-graphql-client v0.13.1/go.mod h1:k7FF7h53C+hSNFRG3++DdVZWIuHdCaTbI7siTJ//zGQ=
+github.com/hasura/go-graphql-client v0.14.3 h1:7La92TuA/FRkVmFd1IN8E+WGW8Lxyn6NKOXAgWcoBDA=
+github.com/hasura/go-graphql-client v0.14.3/go.mod h1:jfSZtBER3or+88Q9vFhWHiFMPppfYILRyl+0zsgPIIw=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -193,6 +193,8 @@ github.com/open-policy-agent/opa v0.67.1 h1:rzy26J6g1X+CKknAcx0Vfbt41KqjuSzx4E0A
 github.com/open-policy-agent/opa v0.67.1/go.mod h1:aqKlHc8E2VAAylYE9x09zJYr/fYzGX+JKne89UGqFzk=
 github.com/opslevel/moredefaults v0.0.0-20240529152742-17d1318a3c12 h1:OQZ3W8kbyCcdS8QUWFTnZd6xtdkfhdckc7Paro7nXio=
 github.com/opslevel/moredefaults v0.0.0-20240529152742-17d1318a3c12/go.mod h1:g2GSXVP6LO+5+AIsnMRPN+BeV86OXuFRTX7HXCDtYeI=
+github.com/opslevel/opslevel-go/v2025 v2025.5.28 h1:LCkgLakF0MWIHMmgQHr3ldNjcO8CB4fLcs/LnRZXnHU=
+github.com/opslevel/opslevel-go/v2025 v2025.5.28/go.mod h1:QiYGhFPwJj3V4efdiY3gqWlU0ZFMcJDiWPnQkPYKSYA=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
Resolves #

### Problem

Untill now the CLI has been on opslevel-go 2024 because of a huge nullability shift along with a number of struct interface changes due to code-gen and standardization.  This has prevented us from upgrading the CLI.

### Solution

Paydown this tech debt and make it so the CLI is on the latest opslevel-go release.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/cli/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
