### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Security
 
 on:

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Integration Tests
 
 on:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ on:
       - 'go.mod'
       - .github/workflows/tests.yml
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OpsLevel/cli/security/code-scanning/11](https://github.com/OpsLevel/cli/security/code-scanning/11)

To fix this problem, explicitly set the `permissions` for the workflow, limiting the `GITHUB_TOKEN` permissions granted to jobs. The best way is to add a `permissions:` block at the root level of the workflow (above `jobs:`), specifying the minimal required permissions. In this case, likely only `contents: read` is required—a conservative and safe default. This prevents excessive access, minimizing risk while preserving current functionality. To fix this, insert:

```yaml
permissions:
  contents: read
```

after the workflow `name`, events (`on:`), and before `jobs:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
