### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: "Reports"
 
 # Every Monday at 1PM UTC (9AM EST)


### PR DESCRIPTION
Potential fix for [https://github.com/OpsLevel/cli/security/code-scanning/9](https://github.com/OpsLevel/cli/security/code-scanning/9)

The best way to fix this issue is to explicitly specify the `permissions` block at the root of the workflow YAML to restrict the default permissions granted to the GITHUB_TOKEN. Since the jobs only read repository contents (via `actions/checkout`) and do not modify anything, the workflow should restrict permissions to `contents: read`, which is the safest minimum. Place the following block at the root, immediately after the workflow `name` (line 1), and before the `on:` field (line 4), in the `.github/workflows/reports.yml` file:

```yaml
permissions:
  contents: read
```

This ensures that unless individual jobs or steps override it, the workflow will only grant read access to repository contents, reducing the risk associated with overly permissive default settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
