### PR TITLE
fix: remove unsupported --dir flag from changie batch and merge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,8 +74,8 @@ jobs:
           then
             echo "Skip Changie..."
           else
-            (cd src && go tool changie batch --dir .. ${{ steps.version.outputs.RELEASE_VERSION }})
-            (cd src && go tool changie merge --dir ..)
+            (cd src && go tool changie batch ${{ steps.version.outputs.RELEASE_VERSION }})
+            (cd src && go tool changie merge)
             git add .
             git commit -m "Cut Release '${{ steps.version.outputs.RELEASE_VERSION }}'"
             git push origin HEAD


### PR DESCRIPTION
## What

Removes the `--dir ..` flag from the `changie batch` and `changie merge` calls in the release workflow.

## Why

https://github.com/OpsLevel/cli/actions/runs/28973368904

The release workflow has been failing with:

```
Error: unknown flag: --dir
```

The `--dir` flag was removed in a newer version of `changie`. Running from the `src/` subdirectory still works correctly without it — changie locates the `.changes/` directory by walking up to the git root automatically.

## Is it safe to merge?

Yes. Verified locally that `go tool changie batch <version> --dry-run` runs correctly from `src/` without the flag and finds the `.changes/` directory at the repo root.